### PR TITLE
PMM-7433 Show "expr" in alert rule details

### DIFF
--- a/public/app/features/integrated-alerting/components/AlertRules/AlertRules.types.ts
+++ b/public/app/features/integrated-alerting/components/AlertRules/AlertRules.types.ts
@@ -55,6 +55,7 @@ export interface AlertRule {
   summary: string;
   threshold: string;
   rawValues: AlertRulesListResponseRule;
+  expr: string;
 }
 
 export interface AlertRulesListPayloadFilter {
@@ -94,6 +95,7 @@ export interface AlertRulesListResponseRule {
   severity: keyof typeof AlertRuleSeverity;
   summary: string;
   template: AlertRulesListPayloadTemplate;
+  expr: string;
   rule_id: string;
   custom_labels?: AlertRulePayloadCustomLabels;
 }

--- a/public/app/features/integrated-alerting/components/AlertRules/AlertRules.utils.test.ts
+++ b/public/app/features/integrated-alerting/components/AlertRules/AlertRules.utils.test.ts
@@ -142,6 +142,8 @@ describe('AlertRulesTable utils', () => {
           ],
           summary: 'Test 1',
         },
+        expr:
+          'sum by (node_name) (mongodb_ss_connections{conn_type="current"}) * 1024 * 1024↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> [[ .threshold ]]',
       },
       ruleId: 'test 1',
       createdAt: '2020-11-25 16:53:39.366',
@@ -152,6 +154,8 @@ describe('AlertRulesTable utils', () => {
       summary: 'Database down - HR - Prod',
       threshold: 'true',
       lastNotified: '2020-11-25 16:53:39.366',
+      expr:
+        'sum by (node_name) (mongodb_ss_connections{conn_type="current"}) * 1024 * 1024↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> [[ .threshold ]]',
     });
 
     expect(formatRule(rulesStubs[3])).toEqual({
@@ -211,6 +215,8 @@ describe('AlertRulesTable utils', () => {
           ],
           summary: 'Test 4',
         },
+        expr:
+          'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
       },
       ruleId: 'test 4',
       createdAt: '2020-11-25 16:53:39.366',
@@ -221,6 +227,8 @@ describe('AlertRulesTable utils', () => {
       summary: 'High network throughput in - Mnfcg - Dev',
       threshold: '75 %',
       lastNotified: '',
+      expr:
+        'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
     });
   });
 
@@ -279,6 +287,8 @@ describe('AlertRulesTable utils', () => {
             ],
             summary: 'Test 1',
           },
+          expr:
+            'sum by (node_name) (mongodb_ss_connections{conn_type="current"}) * 1024 * 1024↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> [[ .threshold ]]',
         },
         ruleId: 'test 1',
         createdAt: '2020-11-25 16:53:39.366',
@@ -289,6 +299,8 @@ describe('AlertRulesTable utils', () => {
         summary: 'Database down - HR - Prod',
         threshold: 'true',
         lastNotified: '2020-11-25 16:53:39.366',
+        expr:
+          'sum by (node_name) (mongodb_ss_connections{conn_type="current"}) * 1024 * 1024↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> [[ .threshold ]]',
       },
       {
         rawValues: {
@@ -347,6 +359,8 @@ describe('AlertRulesTable utils', () => {
             ],
             summary: 'Test 4',
           },
+          expr:
+            'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
         },
         ruleId: 'test 4',
         createdAt: '2020-11-25 16:53:39.366',
@@ -357,6 +371,8 @@ describe('AlertRulesTable utils', () => {
         summary: 'High network throughput in - Mnfcg - Dev',
         threshold: '75 %',
         lastNotified: '',
+        expr:
+          'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
       },
     ]);
   });

--- a/public/app/features/integrated-alerting/components/AlertRules/AlertRules.utils.ts
+++ b/public/app/features/integrated-alerting/components/AlertRules/AlertRules.utils.ts
@@ -74,6 +74,7 @@ export const formatRule = (rule: AlertRulesListResponseRule): AlertRule => {
     severity,
     summary,
     params,
+    expr,
   } = rule;
 
   return {
@@ -87,6 +88,7 @@ export const formatRule = (rule: AlertRulesListResponseRule): AlertRule => {
     threshold: formatThreshold(template, params),
     lastNotified: last_notified ? moment(last_notified).format('YYYY-MM-DD HH:mm:ss.SSS') : '',
     rawValues: rule,
+    expr,
   };
 };
 

--- a/public/app/features/integrated-alerting/components/AlertRules/AlertRulesTable/AlertRulesTable.test.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRules/AlertRulesTable/AlertRulesTable.test.tsx
@@ -68,7 +68,7 @@ describe('AlertRulesTable', () => {
         <AlertRulesTable data={formattedRulesStubs} columns={columns} emptyMessage="empty" />
       </AlertRulesProvider.Provider>
     );
-
-    expect(wrapper.find(dataQa('alert-rules-details'))).toHaveLength(1);
+    const details = wrapper.find(dataQa('alert-rules-details'));
+    expect(details.text().length).toBeGreaterThan(0);
   });
 });

--- a/public/app/features/integrated-alerting/components/AlertRules/AlertRulesTable/AlertRulesTable.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRules/AlertRulesTable/AlertRulesTable.tsx
@@ -61,7 +61,7 @@ export const AlertRulesTable: FC<AlertRulesTableProps> = ({ pendingRequest, data
                       <tr>
                         <td colSpan={columns.length}>
                           <pre data-qa="alert-rules-details" className={style.details}>
-                            {alertRule.rawValues.template.yaml}
+                            {alertRule.expr}
                           </pre>
                         </td>
                       </tr>

--- a/public/app/features/integrated-alerting/components/AlertRules/__mocks__/alertRulesStubs.ts
+++ b/public/app/features/integrated-alerting/components/AlertRules/__mocks__/alertRulesStubs.ts
@@ -48,6 +48,8 @@ export const rulesStubs: AlertRulesListResponseRule[] = [
         },
       ],
     },
+    expr:
+      'sum by (node_name) (mongodb_ss_connections{conn_type="current"}) * 1024 * 1024↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> [[ .threshold ]]',
   },
   {
     rule_id: 'test 2',
@@ -96,6 +98,8 @@ export const rulesStubs: AlertRulesListResponseRule[] = [
         },
       ],
     },
+    expr:
+      'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
   },
   {
     rule_id: 'test 3',
@@ -137,6 +141,8 @@ export const rulesStubs: AlertRulesListResponseRule[] = [
         },
       ],
     },
+    expr:
+      'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
   },
   {
     rule_id: 'test 4',
@@ -188,6 +194,8 @@ export const rulesStubs: AlertRulesListResponseRule[] = [
         },
       ],
     },
+    expr:
+      'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
   },
   {
     rule_id: 'test 5',
@@ -229,6 +237,8 @@ export const rulesStubs: AlertRulesListResponseRule[] = [
         },
       ],
     },
+    expr:
+      'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
   },
   {
     rule_id: 'test 6',
@@ -270,6 +280,8 @@ export const rulesStubs: AlertRulesListResponseRule[] = [
         },
       ],
     },
+    expr:
+      'sum by (node_name) (mongodb_ss_mem_resident * 1024 * 1024)↵/ on (node_name) (node_memory_MemTotal_bytes)↵* 100↵> 20',
   },
 ];
 


### PR DESCRIPTION
What this PR does / why we need it: Show an alert's parsed expression instead of the rule's YAML.

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7433

# Implementation details
Added `expr` (coming now from the API) in both `AlertRule` and `AlertRulesListResponseRule`. Then, just changed the table to show `alertRule.expr` in the `<pre>` block.

# Screenshots
<img width="1429" alt="Screenshot 2021-02-04 at 16 06 00" src="https://user-images.githubusercontent.com/4190654/106920391-f270b400-6702-11eb-9818-a77a8492642e.png">
