### PR TITLE
PMM-7260: edit rule name

### DIFF
--- a/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.test.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.test.tsx
@@ -27,10 +27,12 @@ describe('AddAlertRuleModal', () => {
     threshold: '1 %',
     lastNotified: '',
     disabled: false,
+    expr: '',
     rawValues: {
       channels: [],
       filters: [],
       disabled: false,
+      expr: '',
       template: {
         name: 'pmm_mongodb_connections_memory_usage',
         summary: 'Memory used by MongoDB connections',

--- a/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.test.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.test.tsx
@@ -112,4 +112,14 @@ describe('AddAlertRuleModal', () => {
 
     expect(button.props().disabled).toBe(true);
   });
+
+  it('should disable template edition', () => {
+    const wrapper = mount(<AddAlertRuleModal setVisible={jest.fn()} isVisible alertRule={initialValues} />);
+    expect(
+      wrapper
+        .find(dataQa('template-select-input'))
+        .first()
+        .prop('disabled')
+    ).toBeTruthy();
+  });
 });

--- a/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.tsx
@@ -90,25 +90,22 @@ export const AddAlertRuleModal: FC<AddAlertRuleModalProps> = ({ isVisible, setVi
         onSubmit={onSubmit}
         render={({ handleSubmit, valid, pristine, submitting }) => (
           <form className={styles.form} onSubmit={handleSubmit} data-qa="add-alert-rule-modal-form">
-            {alertRule ? null : (
-              <>
-                <Field name="template" validate={required}>
-                  {({ input }) => (
-                    <>
-                      <label className={styles.label} data-qa="template-select-label">
-                        {Messages.templateField}
-                      </label>
-                      <Select
-                        className={styles.select}
-                        options={templateOptions}
-                        {...input}
-                        data-qa="template-select-input"
-                      />
-                    </>
-                  )}
-                </Field>
-              </>
-            )}
+            <Field name="template" validate={required}>
+              {({ input }) => (
+                <>
+                  <label className={styles.label} data-qa="template-select-label">
+                    {Messages.templateField}
+                  </label>
+                  <Select
+                    disabled={!!alertRule}
+                    className={styles.select}
+                    options={templateOptions}
+                    {...input}
+                    data-qa="template-select-input"
+                  />
+                </>
+              )}
+            </Field>
 
             <TextInputField label={Messages.nameField} name="name" validators={nameValidators} />
 

--- a/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.tsx
@@ -107,10 +107,10 @@ export const AddAlertRuleModal: FC<AddAlertRuleModalProps> = ({ isVisible, setVi
                     </>
                   )}
                 </Field>
-
-                <TextInputField label={Messages.nameField} name="name" validators={nameValidators} />
               </>
             )}
+
+            <TextInputField label={Messages.nameField} name="name" validators={nameValidators} />
 
             <TextInputField label={Messages.thresholdField} name="threshold" />
 


### PR DESCRIPTION
What this PR does / why we need it: Allows editing an alert rule's name. While on edition, the template used is also shown, even though it's blocked.

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7260

# Implementation
- Always show name field (was hidden while on edition);
- When on edition, just `disable` the template `Select` instead of hiding it.

# Screenshot
![Screenshot 2021-02-25 at 10 37 46](https://user-images.githubusercontent.com/4190654/109141714-f3bb5c80-7755-11eb-8b2f-b40e90e5c203.png)
