### PR TITLE
PMM-7375: Send tempate name while editing

### DIFF
--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.styles.ts
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.styles.ts
@@ -1,0 +1,15 @@
+import { GrafanaTheme } from '@grafana/data';
+import { css } from 'emotion';
+
+export const getStyles = ({ colors, spacing }: GrafanaTheme) => ({
+  warningWrapper: css`
+    display: flex;
+    align-items: center;
+    background-color: ${colors.bg2};
+    padding: ${spacing.sm};
+    margin-bottom: ${spacing.xl};
+  `,
+  warningIcon: css`
+    margin-right: ${spacing.sm};
+  `,
+});

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.test.tsx
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Icon } from '@grafana/ui';
+import { WarningBlock } from './WarningBlock';
+
+describe('WarningBlock', () => {
+  it('should have warning icon and message', () => {
+    const wrapper = shallow(<WarningBlock message="message" />);
+    expect(wrapper.find(Icon).prop('name')).toBe('info-circle');
+    expect(wrapper.text()).toBe('message');
+  });
+});

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.test.tsx
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.test.tsx
@@ -9,4 +9,9 @@ describe('WarningBlock', () => {
     expect(wrapper.find(Icon).prop('name')).toBe('info-circle');
     expect(wrapper.text()).toBe('message');
   });
+
+  it('should change icon', () => {
+    const wrapper = shallow(<WarningBlock message="message" type="warning" />);
+    expect(wrapper.find(Icon).prop('name')).toBe('exclamation-triangle');
+  });
 });

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.tsx
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.tsx
@@ -8,11 +8,11 @@ const WarningIconMap: Record<WarningType, IconName> = {
   warning: 'exclamation-triangle',
 };
 
-export const WarningBlock: FC<WarningBlockProps> = ({ message, type = 'info' }) => {
+export const WarningBlock: FC<WarningBlockProps> = ({ message, type = 'info', dataQa = 'warning-block' }) => {
   const styles = useStyles(getStyles);
 
   return (
-    <div className={styles.warningWrapper}>
+    <div className={styles.warningWrapper} data-qa={dataQa}>
       <Icon className={styles.warningIcon} size="xl" name={WarningIconMap[type]} />
       <span>{message}</span>
     </div>

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.tsx
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.tsx
@@ -1,14 +1,19 @@
 import React, { FC } from 'react';
-import { Icon, useStyles } from '@grafana/ui';
-import { WarningBlockProps } from './WarningBlock.types';
+import { Icon, IconName, useStyles } from '@grafana/ui';
+import { WarningBlockProps, WarningType } from './WarningBlock.types';
 import { getStyles } from './WarningBlock.styles';
 
-export const WarningBlock: FC<WarningBlockProps> = ({ message }) => {
+const WarningIconMap: Record<WarningType, IconName> = {
+  info: 'info-circle',
+  warning: 'exclamation-triangle',
+};
+
+export const WarningBlock: FC<WarningBlockProps> = ({ message, type = 'info' }) => {
   const styles = useStyles(getStyles);
 
   return (
     <div className={styles.warningWrapper}>
-      <Icon className={styles.warningIcon} size="xl" name="info-circle" />
+      <Icon className={styles.warningIcon} size="xl" name={WarningIconMap[type]} />
       <span>{message}</span>
     </div>
   );

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.tsx
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from 'react';
+import { Icon, useStyles } from '@grafana/ui';
+import { WarningBlockProps } from './WarningBlock.types';
+import { getStyles } from './WarningBlock.styles';
+
+export const WarningBlock: FC<WarningBlockProps> = ({ message }) => {
+  const styles = useStyles(getStyles);
+
+  return (
+    <div className={styles.warningWrapper}>
+      <Icon className={styles.warningIcon} size="xl" name="info-circle" />
+      <span>{message}</span>
+    </div>
+  );
+};

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.types.ts
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.types.ts
@@ -1,0 +1,3 @@
+export interface WarningBlockProps {
+  message: string;
+}

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.types.ts
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.types.ts
@@ -3,4 +3,5 @@ export type WarningType = 'info' | 'warning';
 export interface WarningBlockProps {
   message: string;
   type?: WarningType;
+  dataQa?: string;
 }

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.types.ts
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/WarningBlock.types.ts
@@ -1,3 +1,6 @@
+export type WarningType = 'info' | 'warning';
+
 export interface WarningBlockProps {
   message: string;
+  type?: WarningType;
 }

--- a/public/app/features/backup/components/StorageLocations/WarningBlock/index.tsx
+++ b/public/app/features/backup/components/StorageLocations/WarningBlock/index.tsx
@@ -1,0 +1,1 @@
+export * from './WarningBlock';

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.types.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.types.ts
@@ -4,6 +4,7 @@ export interface UploadAlertRuleTemplatePayload {
 
 export interface UpdateAlertRuleTemplatePayload {
   yaml: string;
+  name: string;
 }
 
 export interface DeleteAlertRuleTemplatePayload {

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplateActions/AlertRuleTemplateActions.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplateActions/AlertRuleTemplateActions.tsx
@@ -10,7 +10,7 @@ export const AlertRuleTemplateActions: FC<AlertRuleTemplateActionsProps> = ({ te
   const styles = useStyles(getStyles);
   const [editModalVisible, setEditModalVisible] = useState(false);
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
-  const { source, yaml, name } = template;
+  const { source, yaml, name, summary } = template;
   const isActionDisabled = useMemo(() => source === SourceDescription.BUILT_IN, [template]);
 
   return (
@@ -30,6 +30,7 @@ export const AlertRuleTemplateActions: FC<AlertRuleTemplateActionsProps> = ({ te
       <EditAlertRuleTemplateModal
         yaml={yaml}
         name={name}
+        summary={summary}
         isVisible={editModalVisible}
         setVisible={setEditModalVisible}
         getAlertRuleTemplates={getAlertRuleTemplates}

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplateActions/AlertRuleTemplateActions.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplateActions/AlertRuleTemplateActions.tsx
@@ -10,7 +10,7 @@ export const AlertRuleTemplateActions: FC<AlertRuleTemplateActionsProps> = ({ te
   const styles = useStyles(getStyles);
   const [editModalVisible, setEditModalVisible] = useState(false);
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
-  const { source, yaml } = template;
+  const { source, yaml, name } = template;
   const isActionDisabled = useMemo(() => source === SourceDescription.BUILT_IN, [template]);
 
   return (
@@ -29,6 +29,7 @@ export const AlertRuleTemplateActions: FC<AlertRuleTemplateActionsProps> = ({ te
       />
       <EditAlertRuleTemplateModal
         yaml={yaml}
+        name={name}
         isVisible={editModalVisible}
         setVisible={setEditModalVisible}
         getAlertRuleTemplates={getAlertRuleTemplates}

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.constants.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.constants.ts
@@ -1,0 +1,1 @@
+export const MAX_TITLE_LENGTH = 35;

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.messages.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.messages.ts
@@ -3,6 +3,6 @@ export const Messages = {
   submitButton: 'Save',
   cancelAction: 'Cancel',
   editSuccess: 'Alert rule template successfully edited',
-  nameNotEditable: "Name can't be changed. If you need to change it, please create a new Template.",
+  nameNotEditable: 'Name cannot be changed. If you need to change it, please create a new Template.',
   getTitle: (name: string) => `Edit "${name}" Alert Rule Template`,
 };

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.messages.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.messages.ts
@@ -1,7 +1,8 @@
 export const Messages = {
   alertRuleTemplateLabel: 'Alert Rule Template',
   submitButton: 'Save',
-  title: 'Edit Alert Rule Template',
   cancelAction: 'Cancel',
   editSuccess: 'Alert rule template successfully edited',
+  nameNotEditable: 'Warning: "name" can\'t be changed. If you need to change it, please create a new Template.',
+  getTitle: (name: string) => `Edit "${name}" Alert Rule Template`,
 };

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.messages.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.messages.ts
@@ -3,6 +3,6 @@ export const Messages = {
   submitButton: 'Save',
   cancelAction: 'Cancel',
   editSuccess: 'Alert rule template successfully edited',
-  nameNotEditable: 'Warning: "name" can\'t be changed. If you need to change it, please create a new Template.',
+  nameNotEditable: "Name can't be changed. If you need to change it, please create a new Template.",
   getTitle: (name: string) => `Edit "${name}" Alert Rule Template`,
 };

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.styles.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.styles.ts
@@ -1,7 +1,16 @@
+import { GrafanaTheme } from '@grafana/data';
 import { css } from 'emotion';
 
-export const getStyles = () => ({
+export const getStyles = ({ spacing }: GrafanaTheme) => ({
   alertRuleTemplate: css`
     min-height: 250px;
+  `,
+  field: css`
+    &:not(:last-child) {
+      margin-bottom: 0;
+    }
+  `,
+  warning: css`
+    margin-bottom: ${spacing.formInputMargin};
   `,
 });

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.test.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.test.tsx
@@ -12,6 +12,7 @@ describe('EditAlertRuleTemplateModal', () => {
     const wrapper = mount(
       <EditAlertRuleTemplateModal
         name="template-1"
+        summary="summary"
         setVisible={jest.fn()}
         isVisible
         yaml=""
@@ -31,6 +32,7 @@ describe('EditAlertRuleTemplateModal', () => {
     const wrapper = mount(
       <EditAlertRuleTemplateModal
         name="template-1"
+        summary="summary"
         setVisible={jest.fn()}
         isVisible={false}
         yaml=""
@@ -46,6 +48,7 @@ describe('EditAlertRuleTemplateModal', () => {
     const wrapper = mount(
       <EditAlertRuleTemplateModal
         name="template-1"
+        summary="summary"
         setVisible={setVisible}
         isVisible
         yaml=""
@@ -62,6 +65,7 @@ describe('EditAlertRuleTemplateModal', () => {
     const wrapper = mount(
       <EditAlertRuleTemplateModal
         name="template-1"
+        summary="summary"
         setVisible={jest.fn()}
         isVisible
         yaml="test content"
@@ -80,6 +84,7 @@ describe('EditAlertRuleTemplateModal', () => {
     const wrapper = mount(
       <EditAlertRuleTemplateModal
         name="template-1"
+        summary="summary"
         setVisible={setVisible}
         isVisible
         yaml=""

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.test.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.test.tsx
@@ -10,7 +10,13 @@ jest.mock('app/core/app_events');
 describe('EditAlertRuleTemplateModal', () => {
   it('should render component correctly', () => {
     const wrapper = mount(
-      <EditAlertRuleTemplateModal setVisible={jest.fn()} isVisible yaml="" getAlertRuleTemplates={jest.fn()} />
+      <EditAlertRuleTemplateModal
+        name="template-1"
+        setVisible={jest.fn()}
+        isVisible
+        yaml=""
+        getAlertRuleTemplates={jest.fn()}
+      />
     );
     const addButton = wrapper.find(dataQa('alert-rule-template-edit-button')).find('button');
 
@@ -18,11 +24,18 @@ describe('EditAlertRuleTemplateModal', () => {
     expect(addButton).toBeTruthy();
     expect(addButton.prop('disabled')).toBeTruthy();
     expect(wrapper.find(dataQa('alert-rule-template-cancel-button'))).toBeTruthy();
+    expect(wrapper.find(dataQa('alert-rule-name-warning'))).toBeTruthy();
   });
 
   it('should not render modal when visible is set to false', () => {
     const wrapper = mount(
-      <EditAlertRuleTemplateModal setVisible={jest.fn()} isVisible={false} yaml="" getAlertRuleTemplates={jest.fn()} />
+      <EditAlertRuleTemplateModal
+        name="template-1"
+        setVisible={jest.fn()}
+        isVisible={false}
+        yaml=""
+        getAlertRuleTemplates={jest.fn()}
+      />
     );
 
     expect(wrapper.contains('textarea')).toBeFalsy();
@@ -31,7 +44,13 @@ describe('EditAlertRuleTemplateModal', () => {
   it('should call setVisible on close', () => {
     const setVisible = jest.fn();
     const wrapper = mount(
-      <EditAlertRuleTemplateModal setVisible={setVisible} isVisible yaml="" getAlertRuleTemplates={jest.fn()} />
+      <EditAlertRuleTemplateModal
+        name="template-1"
+        setVisible={setVisible}
+        isVisible
+        yaml=""
+        getAlertRuleTemplates={jest.fn()}
+      />
     );
 
     wrapper.find(dataQa('modal-background')).simulate('click');
@@ -42,6 +61,7 @@ describe('EditAlertRuleTemplateModal', () => {
   it('should render yaml content passed', () => {
     const wrapper = mount(
       <EditAlertRuleTemplateModal
+        name="template-1"
         setVisible={jest.fn()}
         isVisible
         yaml="test content"
@@ -59,6 +79,7 @@ describe('EditAlertRuleTemplateModal', () => {
     const getAlertRuleTemplates = jest.fn();
     const wrapper = mount(
       <EditAlertRuleTemplateModal
+        name="template-1"
         setVisible={setVisible}
         isVisible
         yaml=""

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
@@ -11,6 +11,7 @@ import { Messages } from './EditAlertRuleTemplateModal.messages';
 
 export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = ({
   yaml,
+  name,
   isVisible,
   setVisible,
   getAlertRuleTemplates,
@@ -29,7 +30,7 @@ export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = (
   };
 
   return (
-    <Modal title={Messages.title} isVisible={isVisible} onClose={() => setVisible(false)}>
+    <Modal title={Messages.getTitle(name)} isVisible={isVisible} onClose={() => setVisible(false)}>
       <Form
         initialValues={{ yaml }}
         onSubmit={onSubmit}
@@ -37,11 +38,13 @@ export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = (
           <form onSubmit={handleSubmit}>
             <>
               <TextareaInputField
+                fieldClassName={styles.field}
                 name="yaml"
                 label={Messages.alertRuleTemplateLabel}
                 validators={[required]}
                 className={styles.alertRuleTemplate}
               />
+              <div className={styles.warning}>{Messages.nameNotEditable}</div>
               <HorizontalGroup justify="center" spacing="md">
                 <LoaderButton
                   data-qa="alert-rule-template-edit-button"

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
@@ -13,6 +13,7 @@ import { WarningBlock } from 'app/features/backup/components/StorageLocations/Wa
 export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = ({
   yaml,
   name,
+  summary,
   isVisible,
   setVisible,
   getAlertRuleTemplates,

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
@@ -44,7 +44,9 @@ export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = (
                 validators={[required]}
                 className={styles.alertRuleTemplate}
               />
-              <div className={styles.warning}>{Messages.nameNotEditable}</div>
+              <div data-qa="alert-rule-name-warning" className={styles.warning}>
+                {Messages.nameNotEditable}
+              </div>
               <HorizontalGroup justify="center" spacing="md">
                 <LoaderButton
                   data-qa="alert-rule-template-edit-button"

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
@@ -45,7 +45,7 @@ export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = (
                 validators={[required]}
                 className={styles.alertRuleTemplate}
               />
-              <WarningBlock message={Messages.nameNotEditable} type="warning" />
+              <WarningBlock message={Messages.nameNotEditable} type="warning" dataQa="alert-rule-name-warning" />
               <HorizontalGroup justify="center" spacing="md">
                 <LoaderButton
                   data-qa="alert-rule-template-edit-button"

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
@@ -20,7 +20,7 @@ export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = (
   const { required } = validators;
   const onSubmit = async (values: EditAlertRuleTemplateRenderProps) => {
     try {
-      await AlertRuleTemplateService.update(values);
+      await AlertRuleTemplateService.update({ ...values, name });
       setVisible(false);
       appEvents.emit(AppEvents.alertSuccess, [Messages.editSuccess]);
       getAlertRuleTemplates();

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
@@ -8,6 +8,7 @@ import { EditAlertRuleTemplateModalProps, EditAlertRuleTemplateRenderProps } fro
 import { getStyles } from './EditAlertRuleTemplateModal.styles';
 import { AlertRuleTemplateService } from '../AlertRuleTemplate.service';
 import { Messages } from './EditAlertRuleTemplateModal.messages';
+import { MAX_TITLE_LENGTH } from './EditAlertRuleTemplateModal.constants';
 import { WarningBlock } from 'app/features/backup/components/StorageLocations/WarningBlock';
 
 export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = ({
@@ -20,6 +21,7 @@ export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = (
 }) => {
   const styles = useStyles(getStyles);
   const { required } = validators;
+  let truncatedTitle = summary.length > MAX_TITLE_LENGTH ? `${summary.substring(0, MAX_TITLE_LENGTH - 3)}...` : summary;
   const onSubmit = async (values: EditAlertRuleTemplateRenderProps) => {
     try {
       await AlertRuleTemplateService.update({ ...values, name });
@@ -32,7 +34,7 @@ export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = (
   };
 
   return (
-    <Modal title={Messages.getTitle(name)} isVisible={isVisible} onClose={() => setVisible(false)}>
+    <Modal title={Messages.getTitle(truncatedTitle)} isVisible={isVisible} onClose={() => setVisible(false)}>
       <Form
         initialValues={{ yaml }}
         onSubmit={onSubmit}

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.tsx
@@ -8,6 +8,7 @@ import { EditAlertRuleTemplateModalProps, EditAlertRuleTemplateRenderProps } fro
 import { getStyles } from './EditAlertRuleTemplateModal.styles';
 import { AlertRuleTemplateService } from '../AlertRuleTemplate.service';
 import { Messages } from './EditAlertRuleTemplateModal.messages';
+import { WarningBlock } from 'app/features/backup/components/StorageLocations/WarningBlock';
 
 export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = ({
   yaml,
@@ -44,9 +45,7 @@ export const EditAlertRuleTemplateModal: FC<EditAlertRuleTemplateModalProps> = (
                 validators={[required]}
                 className={styles.alertRuleTemplate}
               />
-              <div data-qa="alert-rule-name-warning" className={styles.warning}>
-                {Messages.nameNotEditable}
-              </div>
+              <WarningBlock message={Messages.nameNotEditable} type="warning" />
               <HorizontalGroup justify="center" spacing="md">
                 <LoaderButton
                   data-qa="alert-rule-template-edit-button"

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.types.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.types.ts
@@ -1,6 +1,7 @@
 export interface EditAlertRuleTemplateModalProps {
   yaml: string;
   name: string;
+  summary: string;
   isVisible: boolean;
   setVisible: (value: boolean) => void;
   getAlertRuleTemplates: () => void;

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.types.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/EditAlertRuleTemplateModal/EditAlertRuleTemplateModal.types.ts
@@ -1,5 +1,6 @@
 export interface EditAlertRuleTemplateModalProps {
   yaml: string;
+  name: string;
   isVisible: boolean;
   setVisible: (value: boolean) => void;
   getAlertRuleTemplates: () => void;


### PR DESCRIPTION
What this PR does / why we need it: The API now requires the name of a given template to be sent when editing. Also, the name of the template is on the modal's title and there's a warning stating that the template's name can't be changed.

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7375

# Implementation
- Add template name modal's title;
- Add warning above buttons;
- Send name along on the API request.

# Screenshot
![Screenshot 2021-02-25 at 11 28 36](https://user-images.githubusercontent.com/4190654/109148256-ec984c80-775d-11eb-95ab-2b8b55771ccc.png)
