### PR TITLE
PMM-7510: add pagination to rule templates

### DIFF
--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.constants.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.constants.ts
@@ -1,0 +1,1 @@
+export const ALERT_RULE_TEMPLATES_TABLE_ID = 'alert-rule-templates';

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.service.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.service.ts
@@ -4,6 +4,7 @@ import {
   UploadAlertRuleTemplatePayload,
   UpdateAlertRuleTemplatePayload,
   DeleteAlertRuleTemplatePayload,
+  AlertRuleTemplateGetPayload,
 } from './AlertRuleTemplate.types';
 
 const BASE_URL = `/v1/management/ia/Templates`;
@@ -12,8 +13,8 @@ export const AlertRuleTemplateService = {
   async upload(payload: UploadAlertRuleTemplatePayload): Promise<void> {
     return api.post(`${BASE_URL}/Create`, payload);
   },
-  async list(): Promise<TemplatesList> {
-    return api.post(`${BASE_URL}/List`, { reload: true });
+  async list(payload: AlertRuleTemplateGetPayload): Promise<TemplatesList> {
+    return api.post(`${BASE_URL}/List`, { ...payload, reload: true });
   },
   async update(payload: UpdateAlertRuleTemplatePayload): Promise<void> {
     return api.post(`${BASE_URL}/Update`, payload);

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.test.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.test.tsx
@@ -4,15 +4,8 @@ import { dataQa } from '@percona/platform-core';
 import { act } from 'react-dom/test-utils';
 import { AlertRuleTemplate } from './AlertRuleTemplate';
 import { AlertRuleTemplateService } from './AlertRuleTemplate.service';
-import { templateStubs } from './__mocks__/alertRuleTemplateStubs';
 
-jest.mock('./AlertRuleTemplate.service', () => ({
-  AlertRuleTemplateService: {
-    list: () => ({
-      templates: templateStubs,
-    }),
-  },
-}));
+jest.mock('./AlertRuleTemplate.service');
 jest.mock('@percona/platform-core', () => {
   const originalModule = jest.requireActual('@percona/platform-core');
   return {

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.types.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/AlertRuleTemplate.types.ts
@@ -10,8 +10,21 @@ export interface DeleteAlertRuleTemplatePayload {
   name: string;
 }
 
+export interface AlertRuleTemplateGetPayload {
+  page_params: {
+    page_size: number;
+    index: number;
+  };
+}
+
+interface AlertRuleTemplatesTotals {
+  total_items: number;
+  total_pages: number;
+}
+
 export interface TemplatesList {
   templates: Template[];
+  totals: AlertRuleTemplatesTotals;
 }
 
 export enum SourceDescription {

--- a/public/app/features/integrated-alerting/components/AlertRuleTemplate/__mocks__/AlertRuleTemplate.service.ts
+++ b/public/app/features/integrated-alerting/components/AlertRuleTemplate/__mocks__/AlertRuleTemplate.service.ts
@@ -9,7 +9,7 @@ export const AlertRuleTemplateService = {
     return Promise.resolve();
   },
   async list(): Promise<TemplatesList> {
-    return { templates: templateStubs };
+    return { templates: templateStubs, totals: { total_pages: 1, total_items: templateStubs.length } };
   },
   async delete(): Promise<void> {
     return Promise.resolve();

--- a/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.tsx
@@ -44,7 +44,12 @@ export const AddAlertRuleModal: FC<AddAlertRuleModalProps> = ({ isVisible, setVi
     try {
       const [channelsListResponse, templatesListResponse] = await Promise.all([
         NotificationChannelService.list(),
-        AlertRuleTemplateService.list(),
+        AlertRuleTemplateService.list({
+          page_params: {
+            index: 0,
+            page_size: Math.pow(10, 5),
+          },
+        }),
       ]);
       setChannelsOptions(formatChannelsOptions(channelsListResponse));
       setTemplateOptions(formatTemplateOptions(templatesListResponse.templates));

--- a/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.tsx
+++ b/public/app/features/integrated-alerting/components/AlertRules/AddAlertRuleModal/AddAlertRuleModal.tsx
@@ -44,10 +44,11 @@ export const AddAlertRuleModal: FC<AddAlertRuleModalProps> = ({ isVisible, setVi
     try {
       const [channelsListResponse, templatesListResponse] = await Promise.all([
         NotificationChannelService.list(),
+        // Asking for only 100 might be considered a limitation
         AlertRuleTemplateService.list({
           page_params: {
             index: 0,
-            page_size: Math.pow(10, 5),
+            page_size: 100,
           },
         }),
       ]);


### PR DESCRIPTION
What this PR does / why we need it: Adds pagination to Alert Rule Templates

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7510

# Implementation
The logic is the same as in Alert rules, no more, no less.