### PR TITLE
PMM-7774: do not close storage location modal on error

### DIFF
--- a/public/app/percona/backup/components/StorageLocations/StorageLocations.tsx
+++ b/public/app/percona/backup/components/StorageLocations/StorageLocations.tsx
@@ -101,12 +101,11 @@ export const StorageLocations: FC = () => {
         await StorageLocationsService.add(formatToRawLocation(location));
         appEvents.emit(AppEvents.alertSuccess, [Messages.addSuccess]);
       }
+      setAddModalVisible(false);
+      setSelectedLocation(null);
       getData();
     } catch (e) {
       logger.error(e);
-    } finally {
-      setAddModalVisible(false);
-      setSelectedLocation(null);
     }
   };
 


### PR DESCRIPTION
https://github.com/Percona-Lab/pmm-submodules/pull/1634

What this PR does / why we need it: only closes modal when API successfully returns

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7774