### PR TITLE
PMM-7823: permissions

### DIFF
--- a/public/app/core/components/sidemenu/TopSection.tsx
+++ b/public/app/core/components/sidemenu/TopSection.tsx
@@ -8,6 +8,7 @@ import { logger } from '@percona/platform-core';
 import { buildIntegratedAlertingMenuItem } from './TopSection.utils';
 import { LinkConfig } from './TopSection.types';
 import { SettingsService } from 'app/percona/settings/Settings.service';
+import { isPmmAdmin } from 'app/percona/shared/helpers/permissions';
 
 const TopSection: FC<any> = () => {
   const [showDBaaS, setShowDBaaS] = useState(false);
@@ -73,7 +74,7 @@ const TopSection: FC<any> = () => {
   };
 
   useEffect(() => {
-    if (config.bootData.user.isGrafanaAdmin) {
+    if (isPmmAdmin(config.bootData.user)) {
       updateMenu();
     }
   }, []);

--- a/public/app/percona/backup/components/StorageLocations/AddStorageLocationModal/AddStorageLocationModal.test.tsx
+++ b/public/app/percona/backup/components/StorageLocations/AddStorageLocationModal/AddStorageLocationModal.test.tsx
@@ -80,7 +80,12 @@ describe('AddStorageLocationModal', () => {
 
   it('should show the "Add" button when no location passed', () => {
     const wrapper = mount(<AddStorageLocationModal location={null} onClose={jest.fn()} onAdd={jest.fn()} isVisible />);
-    expect(wrapper.find(LoaderButton).text()).toBe(Messages.addAction);
+    expect(
+      wrapper
+        .find(dataQa('storage-location-add-button'))
+        .first()
+        .text()
+    ).toBe(Messages.addAction);
   });
 
   it('should show the "Edit" button when a location is passed', () => {
@@ -94,27 +99,22 @@ describe('AddStorageLocationModal', () => {
     const wrapper = mount(
       <AddStorageLocationModal location={location} onClose={jest.fn()} onAdd={jest.fn()} isVisible />
     );
-    expect(wrapper.find(LoaderButton).text()).toBe(Messages.editAction);
+    expect(
+      wrapper
+        .find(dataQa('storage-location-add-button'))
+        .first()
+        .text()
+    ).toBe(Messages.editAction);
   });
 
-  it('should not show the test button if "needsLocationValidation" prop is not passed', () => {
+  it('should have the test button', () => {
     const wrapper = mount(<AddStorageLocationModal location={null} onClose={jest.fn()} onAdd={jest.fn()} isVisible />);
-
-    expect(wrapper.find(dataQa('storage-location-test-button')).exists()).toBeFalsy();
-  });
-
-  it('should show the test button if "needsLocationValidation" prop is passed', () => {
-    const wrapper = mount(
-      <AddStorageLocationModal showLocationValidation location={null} onClose={jest.fn()} onAdd={jest.fn()} isVisible />
-    );
 
     expect(wrapper.find(dataQa('storage-location-test-button')).exists()).toBeTruthy();
   });
 
   it('should disable the test button if the form is invalid', () => {
-    const wrapper = mount(
-      <AddStorageLocationModal showLocationValidation location={null} onClose={jest.fn()} onAdd={jest.fn()} isVisible />
-    );
+    const wrapper = mount(<AddStorageLocationModal location={null} onClose={jest.fn()} onAdd={jest.fn()} isVisible />);
 
     expect(
       wrapper
@@ -133,13 +133,7 @@ describe('AddStorageLocationModal', () => {
       path: '/foo/bar',
     };
     const wrapper = mount(
-      <AddStorageLocationModal
-        location={location}
-        showLocationValidation
-        onClose={jest.fn()}
-        onAdd={jest.fn()}
-        isVisible
-      />
+      <AddStorageLocationModal location={location} onClose={jest.fn()} onAdd={jest.fn()} isVisible />
     );
 
     expect(
@@ -161,7 +155,6 @@ describe('AddStorageLocationModal', () => {
     const wrapper = mount(
       <AddStorageLocationModal
         location={location}
-        showLocationValidation
         waitingLocationValidation
         onClose={jest.fn()}
         onAdd={jest.fn()}

--- a/public/app/percona/backup/components/StorageLocations/AddStorageLocationModal/AddStorageLocationModal.tsx
+++ b/public/app/percona/backup/components/StorageLocations/AddStorageLocationModal/AddStorageLocationModal.tsx
@@ -58,7 +58,6 @@ const required = [validators.required];
 export const AddStorageLocationModal: FC<AddStorageLocationModalProps> = ({
   isVisible,
   location = null,
-  showLocationValidation = false,
   waitingLocationValidation = false,
   onClose = () => null,
   onAdd = () => null,
@@ -97,19 +96,17 @@ export const AddStorageLocationModal: FC<AddStorageLocationModalProps> = ({
               >
                 {location ? Messages.editAction : Messages.addAction}
               </LoaderButton>
-              {showLocationValidation ? (
-                <LoaderButton
-                  type="button"
-                  className={cx(styles.button, styles.testButton)}
-                  data-qa="storage-location-test-button"
-                  size="md"
-                  loading={waitingLocationValidation}
-                  disabled={!valid}
-                  onClick={() => handleTest(values)}
-                >
-                  {Messages.test}
-                </LoaderButton>
-              ) : null}
+              <LoaderButton
+                type="button"
+                className={cx(styles.button, styles.testButton)}
+                data-qa="storage-location-test-button"
+                size="md"
+                loading={waitingLocationValidation}
+                disabled={!valid}
+                onClick={() => handleTest(values)}
+              >
+                {Messages.test}
+              </LoaderButton>
               <Button
                 className={styles.button}
                 data-qa="storage-location-cancel-button"

--- a/public/app/percona/backup/components/StorageLocations/AddStorageLocationModal/AddStorageLocationModal.types.ts
+++ b/public/app/percona/backup/components/StorageLocations/AddStorageLocationModal/AddStorageLocationModal.types.ts
@@ -3,7 +3,6 @@ import { LocationType, StorageLocation } from '../StorageLocations.types';
 export interface AddStorageLocationModalProps {
   isVisible: boolean;
   location: StorageLocation | null;
-  showLocationValidation?: boolean;
   waitingLocationValidation?: boolean;
   onClose: () => void;
   onAdd: (location: StorageLocation) => void;

--- a/public/app/percona/backup/components/StorageLocations/StorageLocations.tsx
+++ b/public/app/percona/backup/components/StorageLocations/StorageLocations.tsx
@@ -2,7 +2,6 @@ import React, { FC, useState, useEffect } from 'react';
 import { Column, Row } from 'react-table';
 import { logger } from '@percona/platform-core';
 import { Button, IconButton, useStyles } from '@grafana/ui';
-import { config } from '@grafana/runtime';
 import { AppEvents } from '@grafana/data';
 import { appEvents } from 'app/core/app_events';
 import { Table } from 'app/percona/integrated-alerting/components/Table/Table';
@@ -73,7 +72,6 @@ export const StorageLocations: FC = () => {
     ],
     []
   );
-  const isAdmin = config.bootData.user.isGrafanaAdmin;
 
   const getData = async () => {
     setPending(true);
@@ -178,7 +176,6 @@ export const StorageLocations: FC = () => {
       <AddStorageLocationModal
         location={selectedLocation}
         isVisible={addModalVisible}
-        showLocationValidation={isAdmin}
         waitingLocationValidation={validatingLocation}
         onClose={() => setAddModalVisible(false)}
         onAdd={onAdd}

--- a/public/app/percona/shared/helpers/permissions.ts
+++ b/public/app/percona/shared/helpers/permissions.ts
@@ -1,3 +1,4 @@
 import { OrgRole } from 'app/types';
+import { User } from 'app/core/services/context_srv';
 
-export const isPmmAdmin = (user: any): boolean => user.isGrafanaAdmin || user.orgRole === OrgRole.Admin;
+export const isPmmAdmin = (user: User): boolean => user.isGrafanaAdmin || user.orgRole === OrgRole.Admin;

--- a/public/app/percona/shared/helpers/permissions.ts
+++ b/public/app/percona/shared/helpers/permissions.ts
@@ -1,0 +1,3 @@
+import { OrgRole } from 'app/types';
+
+export const isPmmAdmin = (user: any): boolean => user.isGrafanaAdmin || user.orgRole === OrgRole.Admin;


### PR DESCRIPTION
https://github.com/Percona-Lab/pmm-submodules/pull/1648

What this PR does / why we need it: fixes the permission problem for non-Server Admins on Grafana

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7823

# Implementation
- creates `isPmmAdmin` function, that checks if a user is either a Server Admin or an Org Admin;
- removes admin check from "Test" button on AddStorageLocationModal, as that's redundant.
