### PR TITLE
PMM-7884 Fix DB cluster tab loading

### DIFF
--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.hooks.ts
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.hooks.ts
@@ -18,7 +18,7 @@ const OPERATORS: Partial<OperatorDatabasesMap> = {
 
 export const useDBClusters = (kubernetes: Kubernetes[]): [DBCluster[], GetDBClustersAction, boolean] => {
   const [dbClusters, setDBClusters] = useState<DBCluster[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   let timer: NodeJS.Timeout;
 
   const getDBClusters = async (triggerLoading = true) => {
@@ -42,9 +42,11 @@ export const useDBClusters = (kubernetes: Kubernetes[]): [DBCluster[], GetDBClus
   };
 
   useEffect(() => {
-    getDBClusters();
+    if (kubernetes && kubernetes.length > 0) {
+      getDBClusters();
 
-    timer = setInterval(() => getDBClusters(false), RECHECK_INTERVAL);
+      timer = setInterval(() => getDBClusters(false), RECHECK_INTERVAL);
+    }
 
     return () => clearTimeout(timer);
   }, [kubernetes]);

--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
@@ -76,12 +76,11 @@ export const DBCluster: FC<DBClusterProps> = ({ kubernetes }) => {
     () => (
       <AddClusterButton
         label={Messages.dbcluster.addAction}
-        disabled={settingsLoading}
         action={() => setAddModalVisible(!addModalVisible)}
         data-qa="dbcluster-add-cluster-button"
       />
     ),
-    [addModalVisible, settingsLoading, settings]
+    [addModalVisible, settings]
   );
 
   const getSettings = async () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Fixes DB Cluster tab in DBaaS not showing loading by default. This is a simple fix but the underlying issue is much bigger and is related to the `TabbedContent` component. Please see: https://jira.percona.com/browse/PMM-7930

**Which issue(s) this PR fixes**: https://jira.percona.com/browse/PMM-7884

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

