### PR TITLE
PMM-7953: disabled backup actions

### DIFF
--- a/public/app/percona/backup/components/BackupInventory/BackupInventoryActions/BackupInventoryActions.tsx
+++ b/public/app/percona/backup/components/BackupInventory/BackupInventoryActions/BackupInventoryActions.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import { useStyles } from '@grafana/ui';
 import { DBIcon } from '../../DBIcon';
+import { Status } from '../BackupInventory.types';
 import { BackupInventoryActionsProps } from './BackupInventoryActions.types';
 import { getStyles } from './BackupInventoryActions.styles';
 import { Messages } from './BackupInventoryActions.messages';
@@ -15,6 +16,7 @@ export const BackupInventoryActions: FC<BackupInventoryActionsProps> = ({ backup
       <DBIcon
         tooltipText={Messages.restoreBackup}
         type="restore"
+        disabled={backup.status !== Status.SUCCESS}
         data-qa="restore-backup-artifact-button"
         role="button"
         onClick={handeClick}

--- a/public/app/percona/backup/components/DBIcon/DBIcon.styles.ts
+++ b/public/app/percona/backup/components/DBIcon/DBIcon.styles.ts
@@ -1,0 +1,13 @@
+import { css } from 'emotion';
+import { GrafanaTheme } from '@grafana/data';
+
+export const getStyles = ({ colors }: GrafanaTheme) => ({
+  disabled: css`
+    color: ${colors.textFaint};
+
+    svg {
+      cursor: not-allowed;
+      pointer-events: none;
+    }
+  `,
+});

--- a/public/app/percona/backup/components/DBIcon/DBIcon.tsx
+++ b/public/app/percona/backup/components/DBIcon/DBIcon.tsx
@@ -1,6 +1,8 @@
 import React, { FC } from 'react';
-import { Tooltip } from '@grafana/ui';
+import { Tooltip, useStyles } from '@grafana/ui';
+import { cx } from 'emotion';
 import { DBIconProps, DBIconMap } from './DBIcon.types';
+import { getStyles } from './DBIcon.styles';
 import { Edit, Delete, See, Restore, Backup } from './assets';
 
 const Icons: DBIconMap = {
@@ -11,18 +13,23 @@ const Icons: DBIconMap = {
   backup: Backup,
 };
 
-export const DBIcon: FC<DBIconProps> = ({ type, size, tooltipText, ...rest }) => {
+export const DBIcon: FC<DBIconProps> = ({ type, size, tooltipText, disabled, ...rest }) => {
   if (!Icons[type]) {
     return null;
   }
+  const styles = useStyles(getStyles);
   const Icon = Icons[type];
-  const IconEl = <Icon size={size} {...rest} />;
+  const IconEl = (
+    <span className={cx({ [styles.disabled]: disabled })}>
+      <Icon size={size} {...rest} />
+    </span>
+  );
 
   return tooltipText ? (
     <Tooltip placement="top" content={tooltipText}>
-      <span>{IconEl}</span>
+      {IconEl}
     </Tooltip>
   ) : (
-    IconEl
+    <>{IconEl}</>
   );
 };

--- a/public/app/percona/backup/components/DBIcon/DBIcon.types.ts
+++ b/public/app/percona/backup/components/DBIcon/DBIcon.types.ts
@@ -4,6 +4,7 @@ export interface DBIconProps extends React.HTMLAttributes<HTMLOrSVGElement> {
   type: DBIconType;
   size?: number;
   tooltipText?: string;
+  disabled?: boolean;
 }
 
 export interface IconProps {


### PR DESCRIPTION
What this PR does / why we need it: some actions for backup artifacts should be disabled depending on their status. In this case in particular, a backup can't be restored unless it has successfully finished.

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-7953

# Implementation
- Add `disabled` prop to `DBIcon`;
- Use Grafana theme's `colors.textFaint` for disabled effect, remove pointer-events and change cursor;