### PR TITLE
PMM-7528 Hide DB cluster list error

### DIFF
--- a/public/app/percona/dbaas/DBaaS.tsx
+++ b/public/app/percona/dbaas/DBaaS.tsx
@@ -11,6 +11,7 @@ import PageWrapper from '../shared/components/PageWrapper/PageWrapper';
 import { TechnicalPreview } from '../shared/components/Elements/TechnicalPreview/TechnicalPreview';
 import { TabbedContent, ContentTab } from '../shared/components/Elements/TabbedContent';
 import { FeatureLoader } from '../shared/components/Elements/FeatureLoader';
+import { isKubernetesListUnavailable } from './components/Kubernetes/Kubernetes.utils';
 
 export const DBaaS: FC = () => {
   const styles = useStyles(getStyles);
@@ -35,7 +36,7 @@ export const DBaaS: FC = () => {
       {
         label: Messages.tabs.dbcluster,
         key: TabKeys.dbclusters,
-        disabled: kubernetes.length === 0,
+        disabled: kubernetes.length === 0 || isKubernetesListUnavailable(kubernetes),
         component: <DBCluster key={TabKeys.dbclusters} kubernetes={kubernetes} />,
       },
     ],

--- a/public/app/percona/dbaas/components/DBCluster/PSMDB.service.ts
+++ b/public/app/percona/dbaas/components/DBCluster/PSMDB.service.ts
@@ -39,7 +39,7 @@ const DBCLUSTER_STATUS_MAP = {
 
 export class PSMDBService extends DBClusterService {
   getDBClusters(kubernetes: Kubernetes): Promise<DBClusterPayload> {
-    return apiManagement.post<any, Kubernetes>('/DBaaS/PSMDBClusters/List', kubernetes);
+    return apiManagement.post<any, Kubernetes>('/DBaaS/PSMDBClusters/List', kubernetes, true);
   }
 
   addDBCluster(dbCluster: DBCluster): Promise<void | DBClusterPayload> {

--- a/public/app/percona/dbaas/components/DBCluster/XtraDB.service.ts
+++ b/public/app/percona/dbaas/components/DBCluster/XtraDB.service.ts
@@ -39,7 +39,7 @@ const DBCLUSTER_STATUS_MAP = {
 
 export class XtraDBService extends DBClusterService {
   getDBClusters(kubernetes: Kubernetes): Promise<DBClusterPayload> {
-    return apiManagement.post<any, Kubernetes>('/DBaaS/XtraDBClusters/List', kubernetes);
+    return apiManagement.post<any, Kubernetes>('/DBaaS/XtraDBClusters/List', kubernetes, true);
   }
 
   addDBCluster(dbCluster: DBCluster): Promise<void | DBClusterPayload> {

--- a/public/app/percona/dbaas/components/Kubernetes/Kubernetes.utils.test.ts
+++ b/public/app/percona/dbaas/components/Kubernetes/Kubernetes.utils.test.ts
@@ -1,0 +1,16 @@
+import { isKubernetesListUnavailable } from './Kubernetes.utils';
+import { KubernetesClusterStatus } from './KubernetesClusterStatus/KubernetesClusterStatus.types';
+import { kubernetesStub } from './__mocks__/kubernetesStubs';
+
+describe('Kubernetes.utils:: ', () => {
+  it('should return false when there are clusters available', () => {
+    expect(isKubernetesListUnavailable(kubernetesStub)).toBeFalsy();
+  });
+  it('should return true when there are no clusters available', () => {
+    const kubernetes = [
+      { ...kubernetesStub[0], status: KubernetesClusterStatus.invalid },
+      { ...kubernetesStub[1], status: KubernetesClusterStatus.unavailable },
+    ];
+    expect(isKubernetesListUnavailable(kubernetes)).toBeTruthy();
+  });
+});

--- a/public/app/percona/dbaas/components/Kubernetes/Kubernetes.utils.ts
+++ b/public/app/percona/dbaas/components/Kubernetes/Kubernetes.utils.ts
@@ -1,0 +1,5 @@
+import { Kubernetes } from './Kubernetes.types';
+import { KubernetesClusterStatus } from './KubernetesClusterStatus/KubernetesClusterStatus.types';
+
+export const isKubernetesListUnavailable = (kubernetes: Kubernetes[]) =>
+  !!!kubernetes.find(k => k.status === KubernetesClusterStatus.ok);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Hide DB cluster list API error, if request fails we don't want to show the error. Rather the related cluster will disappear from the list and the user can see on k8s tab that the k8s that it's trying to access is unavailable

**Which issue(s) this PR fixes**: https://jira.percona.com/browse/PMM-7528

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

