### PR TITLE
PMM-8153: block restore when there is no service

### DIFF
--- a/public/app/percona/backup/components/BackupInventory/BackupInventory.tsx
+++ b/public/app/percona/backup/components/BackupInventory/BackupInventory.tsx
@@ -177,6 +177,7 @@ export const BackupInventory: FC = () => {
         isVisible={restoreModalVisible}
         onClose={handleClose}
         onRestore={handleRestore}
+        noService={!selectedBackup?.serviceId || !selectedBackup?.serviceName}
       />
       <AddBackupModal
         backup={selectedBackup}

--- a/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.messages.ts
+++ b/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.messages.ts
@@ -6,4 +6,5 @@ export const Messages = {
   dataModel: 'Data model',
   restore: 'Restore',
   close: 'Close',
+  noService: 'This service no longer exists. Please choose a compatible one.',
 };

--- a/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.styles.ts
+++ b/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.styles.ts
@@ -1,7 +1,7 @@
 import { css } from 'emotion';
 import { GrafanaTheme } from '@grafana/data';
 
-export const getStyles = ({ colors, typography, spacing }: GrafanaTheme) => ({
+export const getStyles = ({ palette, typography, spacing }: GrafanaTheme) => ({
   formHalvesContainer: css`
     display: flex;
     margin-bottom: ${spacing.formInputMargin};
@@ -29,5 +29,14 @@ export const getStyles = ({ colors, typography, spacing }: GrafanaTheme) => ({
       padding: 7px 8px;
       line-height: ${typography.lineHeight.md};
     }
+  `,
+  errorLine: css`
+    color: ${palette.redBase};
+    font-size: ${typography.size.sm};
+    height: ${typography.size.sm};
+    line-height: ${typography.lineHeight.sm};
+    margin-top: ${spacing.sm};
+    padding: ${spacing.formLabelPadding};
+    text-align: center;
   `,
 });

--- a/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.test.tsx
+++ b/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { dataQa } from '@percona/platform-core';
+import { Backup } from '../BackupInventory.types';
+import { RestoreBackupModal } from './RestoreBackupModal';
+import { BackupStatus, DataModel } from 'app/percona/backup/Backup.types';
+import { Databases } from 'app/percona/shared/core';
+
+describe('RestoreBackupModal', () => {
+  const backup: Backup = {
+    id: 'backup1',
+    name: 'Backup 1',
+    created: 1621956564096,
+    locationId: 'location_1',
+    locationName: 'Location One',
+    serviceId: 'service_1',
+    serviceName: 'Service One',
+    dataModel: DataModel.PHYSICAL,
+    status: BackupStatus.BACKUP_STATUS_SUCCESS,
+    vendor: Databases.mongodb,
+  };
+
+  it('should render', () => {
+    const wrapper = mount(<RestoreBackupModal isVisible backup={backup} onClose={jest.fn()} onRestore={jest.fn()} />);
+    expect(wrapper.find(dataQa('restore-button')).exists()).toBeTruthy();
+    expect(wrapper.find(dataQa('restore-cancel-button')).exists()).toBeTruthy();
+    expect(wrapper.find(dataQa('backup-modal-error')).text()).toHaveLength(0);
+  });
+
+  it('should block restore button and show error when noService is passed and same service is selected', () => {
+    const wrapper = mount(
+      <RestoreBackupModal isVisible noService backup={backup} onClose={jest.fn()} onRestore={jest.fn()} />
+    );
+
+    expect(wrapper.find(dataQa('backup-modal-error')).text()).not.toHaveLength(0);
+    expect(
+      wrapper
+        .find(dataQa('restore-button'))
+        .first()
+        .prop('disabled')
+    ).toBeTruthy();
+  });
+
+  it('should not block restore button or show error when noService is passed and compatible service is selected', () => {
+    const wrapper = mount(
+      <RestoreBackupModal isVisible noService backup={backup} onClose={jest.fn()} onRestore={jest.fn()} />
+    );
+
+    wrapper
+      .find(dataQa('serviceType-radio-button'))
+      .at(1)
+      .simulate('change');
+
+    expect(wrapper.find(dataQa('backup-modal-error')).text()).toHaveLength(0);
+    expect(
+      wrapper
+        .find(dataQa('restore-button'))
+        .first()
+        .prop('disabled')
+    ).toBeFalsy();
+  });
+});

--- a/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.tsx
+++ b/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.tsx
@@ -88,6 +88,9 @@ export const RestoreBackupModal: FC<RestoreBackupModalProps> = ({
                 {Messages.close}
               </Button>
             </HorizontalGroup>
+            <div className={styles.errorLine}>
+              {values.serviceType === ServiceTypeSelect.SAME && noService && Messages.noService}
+            </div>
           </form>
         )}
       />

--- a/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.tsx
+++ b/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.tsx
@@ -88,7 +88,7 @@ export const RestoreBackupModal: FC<RestoreBackupModalProps> = ({
                 {Messages.close}
               </Button>
             </HorizontalGroup>
-            <div className={styles.errorLine}>
+            <div className={styles.errorLine} data-qa="backup-modal-error">
               {values.serviceType === ServiceTypeSelect.SAME && noService && Messages.noService}
             </div>
           </form>

--- a/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.tsx
+++ b/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.tsx
@@ -22,7 +22,13 @@ const serviceTypeOptions: Array<SelectableValue<ServiceTypeSelect>> = [
   },
 ];
 
-export const RestoreBackupModal: FC<RestoreBackupModalProps> = ({ backup, isVisible, onClose, onRestore }) => {
+export const RestoreBackupModal: FC<RestoreBackupModalProps> = ({
+  backup,
+  isVisible,
+  noService = false,
+  onClose,
+  onRestore,
+}) => {
   const styles = useStyles(getStyles);
   const initialValues = backup ? toFormProps(backup) : undefined;
   const handleSubmit = ({ serviceType, service }: RestoreBackupFormProps) => {
@@ -69,7 +75,13 @@ export const RestoreBackupModal: FC<RestoreBackupModalProps> = ({ backup, isVisi
               </div>
             </div>
             <HorizontalGroup justify="center" spacing="md">
-              <LoaderButton data-qa="restore-button" size="md" variant="primary" disabled={!valid} loading={submitting}>
+              <LoaderButton
+                data-qa="restore-button"
+                size="md"
+                variant="primary"
+                disabled={!valid || (values.serviceType === ServiceTypeSelect.SAME && noService)}
+                loading={submitting}
+              >
                 {Messages.restore}
               </LoaderButton>
               <Button data-qa="restore-cancel-button" variant="secondary" onClick={onClose}>

--- a/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.types.ts
+++ b/public/app/percona/backup/components/BackupInventory/RestoreBackupModal/RestoreBackupModal.types.ts
@@ -4,6 +4,7 @@ import { Backup } from '../BackupInventory.types';
 export interface RestoreBackupModalProps {
   isVisible: boolean;
   backup: Backup | null;
+  noService?: boolean;
   onClose: () => void;
   onRestore: (serviceId: string, artifactId: string) => void;
 }


### PR DESCRIPTION
What this PR does / why we need it: when there's no serviceId or serviceName (because it was deleted) for a given backup, block the "restore" button in the modal and show an error message.

Which issue(s) this PR fixes: https://jira.percona.com/browse/PMM-8153