### PR TITLE
PMM-7659 Add external access to DB cluster

### DIFF
--- a/packages/grafana-ui/src/components/Portal/Portal.tsx
+++ b/packages/grafana-ui/src/components/Portal/Portal.tsx
@@ -30,7 +30,7 @@ export class Portal extends PureComponent<Props> {
   render() {
     // Default z-index is high to make sure
     return ReactDOM.createPortal(
-      <div style={{ zIndex: 1051, position: 'relative' }} ref={this.props.forwardedRef}>
+      <div style={{ zIndex: 1061, position: 'relative' }} ref={this.props.forwardedRef}>
         {this.props.children}
       </div>,
       this.node

--- a/public/app/percona/dbaas/DBaaS.messages.ts
+++ b/public/app/percona/dbaas/DBaaS.messages.ts
@@ -72,6 +72,7 @@ export const Messages = {
         memory: 'Memory (GB)',
         cpu: 'CPU',
         disk: 'Disk (GB)',
+        expose: 'External Access',
       },
       steps: {
         basicOptions: 'Basic Options',
@@ -99,6 +100,7 @@ export const Messages = {
         disk: 'Disk',
       },
       resourcesInfo: 'Resource calculations are an estimate',
+      exposeTooltip: 'Allows external access to the database cluster',
     },
     deleteModal: {
       cancel: 'Cancel',
@@ -126,6 +128,11 @@ export const Messages = {
         cpu: 'CPU',
         memory: 'Memory',
         disk: 'Disk',
+        expose: {
+          label: 'External Access',
+          enabled: 'Enabled',
+          disabled: 'Disabled',
+        },
       },
       actions: {
         deleteCluster: 'Delete',

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.tsx
@@ -55,6 +55,7 @@ export const AddDBClusterModal: FC<AddDBClusterModalProps> = ({
     memory,
     cpu,
     disk,
+    expose,
   }: Record<string, any>) => {
     try {
       const dbClusterService = newDBClusterService(databaseType.value);
@@ -68,6 +69,7 @@ export const AddDBClusterModal: FC<AddDBClusterModalProps> = ({
         memory,
         disk,
         databaseImage: databaseVersion.value,
+        expose,
       });
       setVisible(false);
       onDBClusterAdded();

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.types.ts
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.types.ts
@@ -20,4 +20,5 @@ export enum AddDBClusterFields {
   memory = 'memory',
   cpu = 'cpu',
   disk = 'disk',
+  expose = 'expose',
 }

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/DBClusterAdvancedOptions/DBClusterAdvancedOptions.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/DBClusterAdvancedOptions/DBClusterAdvancedOptions.tsx
@@ -26,6 +26,7 @@ import { CPU, Disk, Memory } from '../../../DBaaSIcons';
 import { DBClusterService } from '../../DBCluster.service';
 import { DBClusterAllocatedResources, DBClusterExpectedResources } from '../../DBCluster.types';
 import { newDBClusterService } from '../../DBCluster.utils';
+import { SwitchField } from '../../../Switch/Switch';
 
 export const DBClusterAdvancedOptions: FC<FormRenderProps> = ({ values, form }) => {
   let allocatedTimer: NodeJS.Timeout;
@@ -171,6 +172,11 @@ export const DBClusterAdvancedOptions: FC<FormRenderProps> = ({ values, form }) 
           />
         )}
       </div>
+      <SwitchField
+        name={AddDBClusterFields.expose}
+        label={Messages.dbcluster.addModal.fields.expose}
+        tooltip={Messages.dbcluster.addModal.exposeTooltip}
+      />
       <div className={styles.resourcesRadioWrapper}>
         <RadioButtonGroupField
           name={AddDBClusterFields.resources}

--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.types.ts
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.types.ts
@@ -28,6 +28,7 @@ export interface DBCluster {
   finishedSteps?: number;
   totalSteps?: number;
   databaseImage?: string;
+  expose?: boolean;
 }
 
 export enum DBClusterStatus {
@@ -128,6 +129,8 @@ export interface DBClusterPayload {
   params: DBClusterParamsAPI;
   suspend?: boolean;
   resume?: boolean;
+  expose?: boolean;
+  exposed?: boolean;
 }
 
 export interface DBClusterActionAPI {

--- a/public/app/percona/dbaas/components/DBCluster/DBClusterParameters/DBClusterParameters.test.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBClusterParameters/DBClusterParameters.test.tsx
@@ -16,6 +16,7 @@ describe('DBClusterParameters::', () => {
     const memory = root.find('[data-qa="cluster-parameters-memory"]');
     const cpu = root.find('[data-qa="cluster-parameters-cpu"]');
     const disk = root.find('[data-qa="cluster-parameters-disk"]');
+    const expose = root.find('[data-qa="cluster-parameters-expose"]');
 
     expect(memory).toBeTruthy();
     expect(memory.text()).toContain('Memory:1024 GB');
@@ -23,6 +24,8 @@ describe('DBClusterParameters::', () => {
     expect(cpu.text()).toContain('CPU:1');
     expect(disk).toBeTruthy();
     expect(disk.text()).toContain('Disk:25 GB');
+    expect(expose).toBeTruthy();
+    expect(expose.text()).toContain('External Access:Enabled');
   });
 
   it('renders parameters items correctly with MongoDB cluster', async () => {
@@ -35,6 +38,7 @@ describe('DBClusterParameters::', () => {
     const memory = root.find('[data-qa="cluster-parameters-memory"]');
     const cpu = root.find('[data-qa="cluster-parameters-cpu"]');
     const disk = root.find('[data-qa="cluster-parameters-disk"]');
+    const expose = root.find('[data-qa="cluster-parameters-expose"]');
 
     expect(memory).toBeTruthy();
     expect(memory.text()).toContain('Memory:0 GB');
@@ -42,5 +46,7 @@ describe('DBClusterParameters::', () => {
     expect(cpu.text()).toContain('CPU:0');
     expect(disk).toBeTruthy();
     expect(disk.text()).toContain('Disk:25 GB');
+    expect(expose).toBeTruthy();
+    expect(expose.text()).toContain('External Access:Disabled');
   });
 });

--- a/public/app/percona/dbaas/components/DBCluster/DBClusterParameters/DBClusterParameters.test.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBClusterParameters/DBClusterParameters.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { dataQa } from '@percona/platform-core';
 import { DBClusterParameters } from './DBClusterParameters';
 import { dbClustersStub } from '../__mocks__/dbClustersStubs';
 import { getMount } from 'app/percona/shared/helpers/testUtils';
@@ -11,12 +12,12 @@ describe('DBClusterParameters::', () => {
   it('renders parameters items correctly', async () => {
     const root = await getMount(<DBClusterParameters dbCluster={dbClustersStub[0]} />);
 
-    expect(root.find('[data-qa="cluster-parameters-cluster-name"]')).toBeTruthy();
+    expect(root.find(dataQa('cluster-parameters-cluster-name'))).toBeTruthy();
 
-    const memory = root.find('[data-qa="cluster-parameters-memory"]');
-    const cpu = root.find('[data-qa="cluster-parameters-cpu"]');
-    const disk = root.find('[data-qa="cluster-parameters-disk"]');
-    const expose = root.find('[data-qa="cluster-parameters-expose"]');
+    const memory = root.find(dataQa('cluster-parameters-memory'));
+    const cpu = root.find(dataQa('cluster-parameters-cpu'));
+    const disk = root.find(dataQa('cluster-parameters-disk'));
+    const expose = root.find(dataQa('cluster-parameters-expose'));
 
     expect(memory).toBeTruthy();
     expect(memory.text()).toContain('Memory:1024 GB');
@@ -33,12 +34,12 @@ describe('DBClusterParameters::', () => {
 
     root.update();
 
-    expect(root.find('[data-qa="cluster-parameters-cluster-name"]')).toBeTruthy();
+    expect(root.find(dataQa('cluster-parameters-cluster-name'))).toBeTruthy();
 
-    const memory = root.find('[data-qa="cluster-parameters-memory"]');
-    const cpu = root.find('[data-qa="cluster-parameters-cpu"]');
-    const disk = root.find('[data-qa="cluster-parameters-disk"]');
-    const expose = root.find('[data-qa="cluster-parameters-expose"]');
+    const memory = root.find(dataQa('cluster-parameters-memory'));
+    const cpu = root.find(dataQa('cluster-parameters-cpu'));
+    const disk = root.find(dataQa('cluster-parameters-disk'));
+    const expose = root.find(dataQa('cluster-parameters-expose'));
 
     expect(memory).toBeTruthy();
     expect(memory.text()).toContain('Memory:0 GB');

--- a/public/app/percona/dbaas/components/DBCluster/DBClusterParameters/DBClusterParameters.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBClusterParameters/DBClusterParameters.tsx
@@ -9,6 +9,11 @@ import { DBClusterConnectionItem } from '../DBClusterConnection/DBClusterConnect
 export const DBClusterParameters: FC<DBClusterParametersProps> = ({ dbCluster }) => {
   const styles = useStyles(getStyles);
   const { status } = dbCluster;
+  const {
+    label: exposeLabel,
+    enabled: exposeEnabled,
+    disabled: exposeDisabled,
+  } = Messages.dbcluster.table.parameters.expose;
 
   return (
     <>
@@ -33,6 +38,11 @@ export const DBClusterParameters: FC<DBClusterParametersProps> = ({ dbCluster })
             label={Messages.dbcluster.table.parameters.disk}
             value={`${dbCluster.disk} GB`}
             dataQa="cluster-parameters-disk"
+          />
+          <DBClusterConnectionItem
+            label={exposeLabel}
+            value={dbCluster.expose ? exposeEnabled : exposeDisabled}
+            dataQa="cluster-parameters-expose"
           />
         </div>
       )}

--- a/public/app/percona/dbaas/components/DBCluster/PSMDB.service.ts
+++ b/public/app/percona/dbaas/components/DBCluster/PSMDB.service.ts
@@ -134,6 +134,7 @@ export class PSMDBService extends DBClusterService {
       message: dbCluster.operation?.message,
       finishedSteps: dbCluster.operation?.finished_steps || 0,
       totalSteps: dbCluster.operation?.total_steps || 0,
+      expose: dbCluster.exposed,
     };
   }
 }
@@ -141,6 +142,7 @@ export class PSMDBService extends DBClusterService {
 const toAPI = (dbCluster: DBCluster) => ({
   kubernetes_cluster_name: dbCluster.kubernetesClusterName,
   name: dbCluster.clusterName,
+  expose: dbCluster.expose,
   params: {
     cluster_size: dbCluster.clusterSize,
     replicaset: {

--- a/public/app/percona/dbaas/components/DBCluster/XtraDB.service.ts
+++ b/public/app/percona/dbaas/components/DBCluster/XtraDB.service.ts
@@ -135,6 +135,7 @@ export class XtraDBService extends DBClusterService {
       message: dbCluster.operation?.message,
       finishedSteps: dbCluster.operation?.finished_steps || 0,
       totalSteps: dbCluster.operation?.total_steps || 0,
+      expose: dbCluster.exposed,
     };
   }
 }
@@ -142,6 +143,7 @@ export class XtraDBService extends DBClusterService {
 const toAPI = (dbCluster: DBCluster): DBClusterPayload => ({
   kubernetes_cluster_name: dbCluster.kubernetesClusterName,
   name: dbCluster.clusterName,
+  expose: dbCluster.expose,
   params: {
     cluster_size: dbCluster.clusterSize,
     pxc: {

--- a/public/app/percona/dbaas/components/DBCluster/__mocks__/dbClustersStubs.ts
+++ b/public/app/percona/dbaas/components/DBCluster/__mocks__/dbClustersStubs.ts
@@ -23,6 +23,7 @@ export const dbClustersStub: DBCluster[] = [
     status: DBClusterStatus.ready,
     finishedSteps: 5,
     totalSteps: 10,
+    expose: true,
   },
   {
     kubernetesClusterName: 'Kubernetes Cluster 2',
@@ -34,6 +35,7 @@ export const dbClustersStub: DBCluster[] = [
     disk: 25,
     finishedSteps: 7,
     totalSteps: 7,
+    expose: false,
   },
   {
     kubernetesClusterName: 'Kubernetes Cluster 1',
@@ -46,6 +48,7 @@ export const dbClustersStub: DBCluster[] = [
     status: DBClusterStatus.ready,
     finishedSteps: 1,
     totalSteps: 2,
+    expose: false,
   },
   {
     kubernetesClusterName: 'Kubernetes Cluster 2',
@@ -59,6 +62,7 @@ export const dbClustersStub: DBCluster[] = [
     message: 'Cluster creation failed',
     finishedSteps: 0,
     totalSteps: 2,
+    expose: false,
   },
   {
     kubernetesClusterName: 'Kubernetes Cluster 1',

--- a/public/app/percona/dbaas/components/Switch/Switch.styles.ts
+++ b/public/app/percona/dbaas/components/Switch/Switch.styles.ts
@@ -1,0 +1,37 @@
+import { css } from 'emotion';
+import { GrafanaTheme } from '@grafana/data';
+
+export const getStyles = ({ spacing, palette, typography, colors }: GrafanaTheme) => ({
+  field: css`
+    &:not(:last-child) {
+      margin-bottom: ${spacing.formInputMargin};
+    }
+  `,
+  label: css`
+    display: block;
+    text-align: left;
+    font-size: ${typography.size.md};
+    font-weight: ${typography.weight.semibold};
+    line-height: 1.25;
+    margin: ${spacing.formLabelMargin};
+    padding: ${spacing.formLabelPadding};
+    color: ${colors.formLabel};
+  `,
+  labelWrapper: css`
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    div[class$='-Icon'] {
+      display: flex;
+      margin-left: ${spacing.xs};
+    }
+  `,
+  errorMessage: css`
+    color: ${palette.red};
+    font-size: ${typography.size.sm};
+    height: ${typography.size.sm};
+    line-height: ${typography.lineHeight.sm};
+    margin-top: ${spacing.sm};
+    margin-bottom: ${spacing.xs};
+  `,
+});

--- a/public/app/percona/dbaas/components/Switch/Switch.test.tsx
+++ b/public/app/percona/dbaas/components/Switch/Switch.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { Field } from 'react-final-form';
+import { dataQa, FormWrapper } from '@percona/platform-core';
+import { SwitchField } from './Switch';
+
+describe('SwitchField::', () => {
+  it('should render an input element of type checkbox', () => {
+    const wrapper = mount(
+      <FormWrapper>
+        <SwitchField name="test" />
+      </FormWrapper>
+    );
+
+    const field = wrapper.find(Field);
+
+    expect(field).toHaveLength(1);
+    expect(wrapper.find('input')).toHaveLength(1);
+    expect(wrapper.find('input').props()).toHaveProperty('type', 'checkbox');
+  });
+
+  it('should call passed validators', () => {
+    const validatorOne = jest.fn();
+    const validatorTwo = jest.fn();
+
+    mount(
+      <FormWrapper>
+        <SwitchField name="test" validators={[validatorOne, validatorTwo]} />
+      </FormWrapper>
+    );
+
+    expect(validatorOne).toBeCalledTimes(1);
+    expect(validatorTwo).toBeCalledTimes(1);
+  });
+
+  it('should show no labels if one is not specified', () => {
+    const wrapper = mount(
+      <FormWrapper>
+        <SwitchField name="test" />
+      </FormWrapper>
+    );
+
+    expect(wrapper.find(dataQa('test-field-label')).length).toBe(0);
+  });
+
+  it('should show a label if one is specified', () => {
+    const wrapper = mount(
+      <FormWrapper>
+        <SwitchField label="test label" name="test" />
+      </FormWrapper>
+    );
+
+    expect(wrapper.find(dataQa('test-field-label')).length).toBe(1);
+    expect(wrapper.find(dataQa('test-field-label')).text()).toBe('test label');
+  });
+
+  it('should change the state value when clicked', () => {
+    const wrapper = mount(
+      <FormWrapper>
+        <SwitchField name="test" />
+      </FormWrapper>
+    );
+
+    expect(
+      wrapper
+        .find(dataQa('test-switch'))
+        .at(0)
+        .props()
+    ).toHaveProperty('value', false);
+    wrapper.find('input').simulate('change', { target: { value: true } });
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find(dataQa('test-switch'))
+        .at(0)
+        .props()
+    ).toHaveProperty('value', true);
+  });
+
+  it('should disable switch when `disabled` is passed via props', () => {
+    const wrapper = mount(
+      <FormWrapper>
+        <SwitchField name="test" disabled />
+      </FormWrapper>
+    );
+
+    expect(wrapper.find('input').props()).toHaveProperty('disabled', true);
+  });
+});

--- a/public/app/percona/dbaas/components/Switch/Switch.tsx
+++ b/public/app/percona/dbaas/components/Switch/Switch.tsx
@@ -1,0 +1,49 @@
+import React, { FC, useMemo } from 'react';
+import { Field } from 'react-final-form';
+import { cx } from 'emotion';
+import { Icon, Tooltip, Switch, useStyles } from '@grafana/ui';
+import { compose } from '@percona/platform-core/dist/shared/validators';
+import { SwitchFieldProps } from './Switch.types';
+import { getStyles } from './Switch.styles';
+import { SwitchFieldRenderProps } from './Switch.types';
+
+export const SwitchField: FC<SwitchFieldProps> = ({
+  disabled,
+  fieldClassName,
+  inputProps,
+  label,
+  name,
+  validators,
+  tooltip,
+  tooltipIcon = 'info-circle',
+  ...fieldConfig
+}) => {
+  const styles = useStyles(getStyles);
+  const inputId = `input-${name}-id`;
+  const validate = useMemo(() => (Array.isArray(validators) ? compose(...validators) : undefined), [validators]);
+
+  return (
+    <Field<boolean> {...fieldConfig} type="checkbox" name={name} validate={validate}>
+      {({ input, meta }: SwitchFieldRenderProps) => (
+        <div className={cx(styles.field, fieldClassName)} data-qa={`${name}-field-container`}>
+          {label && (
+            <div className={styles.labelWrapper}>
+              <label className={styles.label} htmlFor={inputId} data-qa={`${name}-field-label`}>
+                {label}
+              </label>
+              {tooltip && (
+                <Tooltip content={<span>{tooltip}</span>} data-qa={`${name}-field-tooltip`}>
+                  <Icon name={tooltipIcon} />
+                </Tooltip>
+              )}
+            </div>
+          )}
+          <Switch {...input} value={input.checked} disabled={disabled} data-qa={`${name}-switch`} />
+          <div data-qa={`${name}-field-error-message`} className={styles.errorMessage}>
+            {meta.touched && meta.error}
+          </div>
+        </div>
+      )}
+    </Field>
+  );
+};

--- a/public/app/percona/dbaas/components/Switch/Switch.types.ts
+++ b/public/app/percona/dbaas/components/Switch/Switch.types.ts
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+import { FieldInputProps, FieldMetaState, UseFieldConfig } from 'react-final-form';
+import { IconName } from '@grafana/ui';
+import { FieldInputAttrs } from '@percona/platform-core/dist/shared/types';
+import { Validator } from '@percona/platform-core/dist/shared/validators';
+
+export interface SwitchFieldRenderProps {
+  input: FieldInputProps<string, HTMLInputElement>;
+  meta: FieldMetaState<string>;
+}
+
+export interface SwitchFieldProps extends UseFieldConfig<boolean> {
+  disabled?: boolean;
+  fieldClassName?: string;
+  inputProps?: FieldInputAttrs;
+  label?: string | ReactNode;
+  name: string;
+  validators?: Validator[];
+  tooltip?: string;
+  tooltipIcon?: IconName;
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: 

- Adds `Switch` to DB Cluster creation page to enable external access for the DB cluster (exposes the cluster to the world)
- New `Switch` component was added that allows a tooltip, the idea is to contribute this Switch to core
- Found a bug in grafana: tooltips have lower z-index than the modal, which means tooltips don't show in the modal because they are hidden underneath. I will later open a PR on grafana to fix it on their side

**Which issue(s) this PR fixes**: https://jira.percona.com/browse/PMM-7659

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

