### PR TITLE
PMM-8265 fix typo in Utilisation

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -158,7 +158,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 	}
 
 	nodeSummaryChildNavs := []*dtos.NavLink{
-		{Text: "CPU Utilisation", Id: "home", Url: setting.AppSubUrl + "/d/node-cpu/cpu-utilization-details", Icon: "percona-cpu", HideFromTabs: true},
+		{Text: "CPU Utilization", Id: "home", Url: setting.AppSubUrl + "/d/node-cpu/cpu-utilization-details", Icon: "percona-cpu", HideFromTabs: true},
 		{Text: "Disk", Id: "home", Url: setting.AppSubUrl + "/d/node-disk/disk-details", Icon: "percona-disk", HideFromTabs: true},
 		{Text: "Memory", Id: "home", Url: setting.AppSubUrl + "/d/node-memory/memory-details", Icon: "percona-memory", HideFromTabs: true},
 		{Text: "Network", Id: "home", Url: setting.AppSubUrl + "/d/node-network/network-details", Icon: "percona-network", HideFromTabs: true},


### PR DESCRIPTION
What this PR does / why we need it:
fix typo in grafana menu Utilisation -> Utilization
![image](https://user-images.githubusercontent.com/90199600/133620611-32079326-38e2-4b4b-9943-3530e9d424f2.png)
Which issue(s) this PR fixes: 
https://jira.percona.com/browse/PMM-8265