### PR TITLE
Create endpoint to retrieve OAuth token

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -91,6 +91,7 @@ func (hs *HTTPServer) Init() error {
 
 	hs.macaron = hs.newMacaron()
 	hs.registerRoutes()
+	hs.registerPerconaRoutes()
 
 	return nil
 }

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -83,9 +83,9 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 		hashedState := hashStatecode(state, setting.OAuthService.OAuthInfos[name].ClientSecret)
 		cookies.WriteCookie(ctx.Resp, OauthStateCookieName, hashedState, hs.Cfg.OAuthCookieMaxAge, hs.CookieOptionsFromCfg)
 		if setting.OAuthService.OAuthInfos[name].HostedDomain == "" {
-			ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOnline))
+			ctx.Redirect(connect.AuthCodeURL(state, oauth2.AccessTypeOffline))
 		} else {
-			ctx.Redirect(connect.AuthCodeURL(state, oauth2.SetAuthURLParam("hd", setting.OAuthService.OAuthInfos[name].HostedDomain), oauth2.AccessTypeOnline))
+			ctx.Redirect(connect.AuthCodeURL(state, oauth2.SetAuthURLParam("hd", setting.OAuthService.OAuthInfos[name].HostedDomain), oauth2.AccessTypeOffline))
 		}
 		return
 	}

--- a/pkg/api/percona_api.go
+++ b/pkg/api/percona_api.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/middleware"
+)
+
+func (hs *HTTPServer) registerPerconaRoutes() {
+	reqSignedIn := middleware.ReqSignedIn
+	reqSignedInNoAnonymous := middleware.ReqSignedInNoAnonymous
+
+	r := hs.RouteRegister
+
+	r.Group("/percona-api", func(apiRoute routing.RouteRegister) {
+		apiRoute.Group("/user", func(userRoute routing.RouteRegister) {
+			userRoute.Get("/oauth-token", routing.Wrap(hs.GetUserOAuthToken))
+		}, reqSignedInNoAnonymous)
+	}, reqSignedIn)
+}

--- a/pkg/api/user_token.go
+++ b/pkg/api/user_token.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/ua-parser/uap-go/uaparser"
 )
@@ -41,6 +42,14 @@ func (hs *HTTPServer) logoutUserFromAllDevicesInternal(ctx context.Context, user
 	return response.JSON(200, util.DynMap{
 		"message": "User logged out",
 	})
+}
+
+func (hs *HTTPServer) GetUserOAuthToken(c *models.ReqContext) response.Response {
+	if token := oauthtoken.GetCurrentOAuthToken(hs.context, c.SignedInUser); token != nil {
+		return response.JSON(200, token)
+	}
+
+	return response.Error(500, "Failed to get token", nil)
 }
 
 func (hs *HTTPServer) getUserAuthTokensInternal(c *models.ReqContext, userID int64) response.Response {


### PR DESCRIPTION
This endpoint will be needed by pmm-managed when disconnecting from Portal.

Format:
`GET /percona-api/user/oauth-token`

Response:
```
{
    access_token: <token>,
    refresh_token: <token>,
    expiry: <expiry>,
    token_type: <type, e.g. "Bearer">
}
```