### PR TITLE
PMM-9193-add-collectios-metrics-fields-to-mongo: fix placeholders

### DIFF
--- a/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.service.tsx
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.service.tsx
@@ -8,7 +8,7 @@ import {
   PostgreSQLInstanceResponse,
   MySQLInstanceResponse,
   AddHaProxyResponse,
-  AddMongoDbReponse,
+  AddMongoDbResponse,
   AddRDSResponse,
   AddExternalResponse,
   ErrorResponse,
@@ -61,7 +61,7 @@ class AddRemoteInstanceService {
   }
 
   static async addMongodb(body: MongoDBPayload, token?: CancelToken) {
-    return apiManagement.post<AddMongoDbReponse | ErrorResponse, RemoteInstancePayload>(
+    return apiManagement.post<AddMongoDbResponse | ErrorResponse, RemoteInstancePayload>(
       '/MongoDB/Add',
       body,
       false,
@@ -180,7 +180,7 @@ export const toPayload = (values: any, discoverName?: string, type?: InstanceAva
       data.disable_collectors = values.disable_collectors.replace(/\s/g, '').split(',');
     }
     if (values.stats_collections) {
-      data.stats_collections = values.stats_collections.replace(/\s/g, '');
+      data.stats_collections = values.stats_collections.replace(/\s/g, '').split(',');
     }
   }
 

--- a/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.types.ts
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.types.ts
@@ -339,12 +339,13 @@ export interface AddHaProxyResponse {
   };
 }
 
-export interface AddMongoDbReponse {
+export interface AddMongoDbResponse {
   service: ExtendedService;
   mongodb_exporter: MongoDbExporter;
   qan_mongodb_profiler: BaseExporter;
   disable_collectors?: string[];
   collections_limit?: number;
+  stats_collections?: string[];
 }
 
 export interface AddRDSResponse {


### PR DESCRIPTION
**What this PR does / why we need it**:
After API changes (https://github.com/percona/pmm/pull/799), we need to change the type of stats_collections in the FE part from string to string[];

**Which issue(s) this PR fixes**:
https://jira.percona.com/browse/PMM-9253
