### PR TITLE
PMM-7 increase timeout for ui-tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x]
-    timeout-minutes: 30
+    timeout-minutes: 50
 
     steps:
       - name: Checkout Grafana code


### PR DESCRIPTION
**What this PR does / why we need it**:
Run ui-tests take an average of 26-28 minutes and a 30-minutes timeout is not enough.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

