### PR TITLE
PMM-9144: Remove mySQL from "AWS RDS MySQL or Aurora MySQL" title

### DIFF
--- a/public/app/percona/add-instance/components/AddInstance/AddInstance.messages.ts
+++ b/public/app/percona/add-instance/components/AddInstance/AddInstance.messages.ts
@@ -1,6 +1,6 @@
 export const Messages = {
   titles: {
-    rds: 'AWS RDS MySQL or Aurora MySQL',
+    rds: 'AWS RDS or Aurora',
     azure: 'Microsoft Azure MySQL or PostgreSQL',
     postgresql: 'PostgreSQL',
     mysql: 'MySQL',

--- a/public/app/percona/add-instance/components/AddInstance/AddInstance.messages.ts
+++ b/public/app/percona/add-instance/components/AddInstance/AddInstance.messages.ts
@@ -1,6 +1,6 @@
 export const Messages = {
   titles: {
-    rds: 'AWS RDS or Aurora',
+    rds: 'Amazon RDS',
     azure: 'Microsoft Azure MySQL or PostgreSQL',
     postgresql: 'PostgreSQL',
     mysql: 'MySQL',

--- a/public/app/percona/add-instance/components/AddInstance/AddInstance.test.tsx
+++ b/public/app/percona/add-instance/components/AddInstance/AddInstance.test.tsx
@@ -18,11 +18,11 @@ describe('AddInstance page::', () => {
   it('should invoke a callback with a proper instance type', async () => {
     const onSelectInstanceType = jest.fn();
 
-    await waitFor(() => render(<AddInstance onSelectInstanceType={onSelectInstanceType} />));
+    render(<AddInstance onSelectInstanceType={onSelectInstanceType} />);
 
     expect(onSelectInstanceType).toBeCalledTimes(0);
 
-    const button = screen.getByTestId('rds-instance');
+    const button = await screen.findByTestId('rds-instance');
     fireEvent.click(button);
 
     expect(onSelectInstanceType).toBeCalledTimes(1);

--- a/public/app/percona/add-instance/components/AddInstance/AddInstance.test.tsx
+++ b/public/app/percona/add-instance/components/AddInstance/AddInstance.test.tsx
@@ -1,27 +1,29 @@
 import React from 'react';
-import { ReactWrapper, shallow, ShallowWrapper } from 'enzyme';
-import { AddInstance, SelectInstance } from './AddInstance';
+import { AddInstance } from './AddInstance';
 import { instanceList } from './AddInstance.constants';
-import { getMount } from 'app/percona/shared/helpers/testUtils';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 jest.mock('app/percona/settings/Settings.service');
 
 describe('AddInstance page::', () => {
-  it('should render a given number of links', () => {
-    const wrapper: ShallowWrapper = shallow(<AddInstance onSelectInstanceType={() => {}} />);
+  it('should render a given number of links', async () => {
+    await waitFor(() => render(<AddInstance onSelectInstanceType={() => {}} />));
 
-    expect(wrapper.find(SelectInstance).length).toEqual(instanceList.length);
+    expect(screen.getAllByRole('button').length).toEqual(instanceList.length);
+    instanceList.forEach((item) => {
+      expect(screen.getByTestId(`${item.type}-instance`)).toBeInTheDocument();
+    });
   });
 
   it('should invoke a callback with a proper instance type', async () => {
     const onSelectInstanceType = jest.fn();
 
-    const wrapper: ReactWrapper = await getMount(<AddInstance onSelectInstanceType={onSelectInstanceType} />);
+    await waitFor(() => render(<AddInstance onSelectInstanceType={onSelectInstanceType} />));
 
     expect(onSelectInstanceType).toBeCalledTimes(0);
 
-    wrapper.update();
-    wrapper.find('[data-testid="rds-instance"]').simulate('click');
+    const button = screen.getByTestId('rds-instance');
+    fireEvent.click(button);
 
     expect(onSelectInstanceType).toBeCalledTimes(1);
     expect(onSelectInstanceType.mock.calls[0][0]).toStrictEqual({ type: 'rds' });

--- a/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.test.tsx
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.test.tsx
@@ -1,60 +1,67 @@
-import { mount } from 'enzyme';
 import React from 'react';
-import { dataTestId } from '@percona/platform-core';
+import { render, screen, fireEvent } from '@testing-library/react';
 import AddRemoteInstance from './AddRemoteInstance';
 import { Databases } from 'app/percona/shared/core';
 import { InstanceTypesExtra } from '../../panel.types';
 
-xdescribe('Add remote instance:: ', () => {
-  it('should render correct for mysql and highlight empty mandatory fields on submit', async () => {
+jest.mock('@percona/platform-core', () => {
+  const originalModule = jest.requireActual('@percona/platform-core');
+  return {
+    ...originalModule,
+    logger: {
+      error: jest.fn(),
+    },
+  };
+});
+
+describe('Add remote instance:: ', () => {
+  it('should render correct for mysql and postgres and highlight empty mandatory fields on submit', async () => {
     const type = Databases.mysql;
+    render(<AddRemoteInstance instance={{ type, credentials: {} }} selectInstance={jest.fn()} />);
 
-    const root = mount(<AddRemoteInstance instance={{ type, credentials: {} }} selectInstance={jest.fn()} />);
+    expect(screen.getByTestId('address-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('username-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('password-password-input').classList.contains('invalid')).toBe(false);
 
-    expect(root.find('input[data-testid="address-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="username-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="password-password-input"].invalid').length).toBe(0);
+    fireEvent.submit(screen.getByTestId('add-remote-instance-form'), {});
 
-    root.find(dataTestId('add-remote-instance-form')).simulate('submit');
-
-    expect(root.find('input[data-testid="address-text-input"].invalid').length).toBe(1);
-    expect(root.find('input[data-testid="username-text-input"].invalid').length).toBe(1);
-    expect(root.find('input[data-testid="password-password-input"].invalid').length).toBe(1);
+    expect(screen.getByTestId('address-text-input').classList.contains('invalid')).toBe(true);
+    expect(screen.getByTestId('username-text-input').classList.contains('invalid')).toBe(true);
+    expect(screen.getByTestId('password-password-input').classList.contains('invalid')).toBe(true);
   });
 
-  it('should render for external service and highlight empty mandatory fields on submit', () => {
+  it('should render for external service and highlight empty mandatory fields on submit', async () => {
     const type = InstanceTypesExtra.external;
+    render(<AddRemoteInstance instance={{ type, credentials: {} }} selectInstance={jest.fn()} />);
 
-    const root = mount(<AddRemoteInstance instance={{ type, credentials: {} }} selectInstance={jest.fn()} />);
+    expect(screen.getByTestId('address-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('metrics_path-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('port-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('username-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('password-password-input').classList.contains('invalid')).toBe(false);
 
-    expect(root.find('input[data-testid="address-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="metrics_path-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="port-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="username-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="password-password-input"].invalid').length).toBe(0);
+    fireEvent.submit(screen.getByTestId('add-remote-instance-form'), {});
 
-    root.find(dataTestId('add-remote-instance-form')).simulate('submit');
-
-    expect(root.find('input[data-testid="address-text-input"].invalid').length).toBe(1);
-    expect(root.find('input[data-testid="metrics_path-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="port-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="username-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="password-password-input"].invalid').length).toBe(0);
+    expect(screen.getByTestId('address-text-input').classList.contains('invalid')).toBe(true);
+    expect(screen.getByTestId('metrics_path-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('port-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('username-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('password-password-input').classList.contains('invalid')).toBe(false);
   });
 
   it('should render correct for HAProxy and highlight empty mandatory fields on submit', async () => {
     const type = Databases.haproxy;
 
-    const root = mount(<AddRemoteInstance instance={{ type, credentials: {} }} selectInstance={jest.fn()} />);
+    render(<AddRemoteInstance instance={{ type, credentials: {} }} selectInstance={jest.fn()} />);
 
-    expect(root.find('input[data-testid="address-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="username-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="password-password-input"].invalid').length).toBe(0);
+    expect(screen.getByTestId('address-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('username-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('password-password-input').classList.contains('invalid')).toBe(false);
 
-    root.find(dataTestId('add-remote-instance-form')).simulate('submit');
+    fireEvent.submit(screen.getByTestId('add-remote-instance-form'), {});
 
-    expect(root.find('input[data-testid="address-text-input"].invalid').length).toBe(1);
-    expect(root.find('input[data-testid="username-text-input"].invalid').length).toBe(0);
-    expect(root.find('input[data-testid="password-password-input"].invalid').length).toBe(0);
+    expect(screen.getByTestId('address-text-input').classList.contains('invalid')).toBe(true);
+    expect(screen.getByTestId('username-text-input').classList.contains('invalid')).toBe(false);
+    expect(screen.getByTestId('password-password-input').classList.contains('invalid')).toBe(false);
   });
 });

--- a/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/ExternalServiceConnectionDetails/ExternalServiceConnectionDetails.test.tsx
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/ExternalServiceConnectionDetails/ExternalServiceConnectionDetails.test.tsx
@@ -1,12 +1,11 @@
-import { mount } from 'enzyme';
 import React from 'react';
-import { dataTestId } from '@percona/platform-core';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { Form } from 'react-final-form';
 import { ExternalServiceConnectionDetails } from './ExternalServiceConnectionDetails';
 
-xdescribe('Add remote instance:: ', () => {
-  it('should render correct for mysql and highlight empty mandatory fields on submit', async () => {
-    const root = mount(
+describe('Add remote instance:: ', () => {
+  it('should render correct for mysql and postgres and highlight empty mandatory fields on submit', async () => {
+    render(
       <Form
         onSubmit={jest.fn()}
         mutators={{
@@ -18,24 +17,18 @@ xdescribe('Add remote instance:: ', () => {
       />
     );
 
-    root.find(dataTestId('metricsParameters-radio-state')).simulate('change', { target: { value: 'parsed' } });
+    const metricsParametrsRadioState = screen.getByTestId('metricsParameters-radio-state');
+    fireEvent.change(metricsParametrsRadioState, { target: { value: 'parsed' } });
 
-    root.update();
+    const urlTextInput = screen.getByTestId('url-text-input');
+    fireEvent.change(urlTextInput, { target: { value: 'https://admin:admin@localhost/metrics' } });
 
-    root
-      .find(dataTestId('url-text-input'))
-      .simulate('change', { target: { value: 'https://admin:admin@localhost/metrics' } });
+    fireEvent.change(metricsParametrsRadioState, { target: { value: 'manually' } });
 
-    root.update();
-
-    root.find(dataTestId('metricsParameters-radio-state')).simulate('change', { target: { value: 'manually' } });
-
-    root.update();
-
-    expect(root.find(dataTestId('address-text-input')).props().value).toEqual('localhost');
-    expect(root.find(dataTestId('metrics_path-text-input')).props().value).toEqual('/metrics');
-    expect(root.find(dataTestId('port-text-input')).props().value).toEqual('443');
-    expect(root.find(dataTestId('username-text-input')).props().value).toEqual('admin');
-    expect(root.find(dataTestId('password-password-input')).props().value).toEqual('admin');
+    expect((screen.getByTestId('address-text-input') as HTMLInputElement).value).toEqual('localhost');
+    expect((screen.getByTestId('metrics_path-text-input') as HTMLInputElement).value).toEqual('/metrics');
+    expect((screen.getByTestId('port-text-input') as HTMLInputElement).value).toEqual('443');
+    expect((screen.getByTestId('username-text-input') as HTMLInputElement).value).toEqual('admin');
+    expect((screen.getByTestId('password-password-input') as HTMLInputElement).value).toEqual('admin');
   });
 });

--- a/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/FormParts.test.tsx
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/FormParts.test.tsx
@@ -1,111 +1,112 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { Form } from 'react-final-form';
-import { FormApi, FormState } from 'final-form';
-import { trackingOptions } from './FormParts.constants';
-import { AdditionalOptionsFormPart, getAdditionalOptions } from './AdditionalOptions/AdditionalOptions';
-import { LabelsFormPart } from './Labels/Labels';
+import { render, screen } from '@testing-library/react';
+// import { FormApi, FormState } from 'final-form';
+// import { trackingOptions } from './FormParts.constants';
+// import { AdditionalOptionsFormPart, getAdditionalOptions } from './AdditionalOptions/AdditionalOptions';
+// import { LabelsFormPart } from './Labels/Labels';
 import { MainDetailsFormPart } from './MainDetails/MainDetails';
 import { ExternalServiceConnectionDetails } from './ExternalServiceConnectionDetails/ExternalServiceConnectionDetails';
 import { getMount } from 'app/percona/shared/helpers/testUtils';
 import { Databases } from 'app/percona/shared/core';
 import { dataTestId } from '@percona/platform-core';
 
-const form: Partial<FormApi> = {
-  change: jest.fn(),
-  getState: () => ({} as FormState<any>),
-};
+// const form: Partial<FormApi> = {
+//   change: jest.fn(),
+//   getState: () => ({} as FormState<any>),
+// };
 
-xdescribe('MainDetailsFormPart ::', () => {
+describe('MainDetailsFormPart ::', () => {
   it('should disable fields with sat isRDS flag', async () => {
-    const root = mount(
+    const { container } = render(
       <Form
         onSubmit={jest.fn()}
         render={({ form }) => <MainDetailsFormPart form={form} remoteInstanceCredentials={{ isRDS: true }} />}
       />
     );
 
-    const fields = root.find('input');
-
+    const fields = container.querySelectorAll('input');
     expect(fields.length).toBe(5);
-    expect(root.find('input[name="address"]').prop('disabled')).toBeTruthy();
-    expect(root.find('input[name="serviceName"]').prop('disabled')).toBeFalsy();
-    expect(root.find('input[name="port"]').prop('disabled')).toBeFalsy();
-    expect(root.find('input[name="username"]').prop('disabled')).toBeFalsy();
-    expect(root.find('input[name="password"]').prop('disabled')).toBeFalsy();
+
+    expect(screen.getByTestId('address-text-input')).toBeDisabled();
+    // expect(root.find('input[name="address"]').prop('disabled')).toBeTruthy();
+    // expect(root.find('input[name="serviceName"]').prop('disabled')).toBeFalsy();
+    // expect(root.find('input[name="port"]').prop('disabled')).toBeFalsy();
+    // expect(root.find('input[name="username"]').prop('disabled')).toBeFalsy();
+    // expect(root.find('input[name="password"]').prop('disabled')).toBeFalsy();
   });
 
-  it('should disable fields with not sat isRDS flag', async () => {
-    const root = mount(
-      <Form
-        onSubmit={jest.fn()}
-        render={({ form }) => <MainDetailsFormPart form={form} remoteInstanceCredentials={{ isRDS: false }} />}
-      />
-    );
-
-    const fields = root.find('input');
-
-    expect(fields.length).toBe(5);
-    expect(root.find('input[name="address"]').prop('disabled')).toBeFalsy();
-    expect(root.find('input[name="serviceName"]').prop('disabled')).toBeFalsy();
-    expect(root.find('input[name="port"]').prop('disabled')).toBeFalsy();
-    expect(root.find('input[name="username"]').prop('disabled')).toBeFalsy();
-    expect(root.find('input[name="password"]').prop('disabled')).toBeFalsy();
-  });
+  // it('should disable fields with not sat isRDS flag', async () => {
+  //   const root = mount(
+  //     <Form
+  //       onSubmit={jest.fn()}
+  //       render={({ form }) => <MainDetailsFormPart form={form} remoteInstanceCredentials={{ isRDS: false }} />}
+  //     />
+  //   );
+  //
+  //   const fields = root.find('input');
+  //
+  //   expect(fields.length).toBe(5);
+  //   expect(root.find('input[name="address"]').prop('disabled')).toBeFalsy();
+  //   expect(root.find('input[name="serviceName"]').prop('disabled')).toBeFalsy();
+  //   expect(root.find('input[name="port"]').prop('disabled')).toBeFalsy();
+  //   expect(root.find('input[name="username"]').prop('disabled')).toBeFalsy();
+  //   expect(root.find('input[name="password"]').prop('disabled')).toBeFalsy();
+  // });
 });
 
 xdescribe('ExternalServiceConnectionDetails ::', () => {
-  it('should render', async () => {
-    const root = mount(
-      <Form
-        onSubmit={jest.fn()}
-        render={() => <ExternalServiceConnectionDetails form={(form as unknown) as FormApi} />}
-      />
-    );
-
-    const fields = root.find('input');
-
-    expect(fields.length).toBe(5);
-  });
+  // it('should render', async () => {
+  //   const root = mount(
+  //     <Form
+  //       onSubmit={jest.fn()}
+  //       render={() => <ExternalServiceConnectionDetails form={(form as unknown) as FormApi} />}
+  //     />
+  //   );
+  //
+  //   const fields = root.find('input');
+  //
+  //   expect(fields.length).toBe(5);
+  // });
 });
 
 xdescribe('LabelsFormPart ::', () => {
-  it('should render correct fields with empty props', async () => {
-    const root = mount(<Form onSubmit={jest.fn()} render={() => <LabelsFormPart />} />);
-
-    const fields = root.find('input');
-    const textArea = root.find('textarea');
-
-    expect(fields.length).toBe(5);
-    expect(textArea.length).toBe(1);
-  });
+  // it('should render correct fields with empty props', async () => {
+  //   const root = mount(<Form onSubmit={jest.fn()} render={() => <LabelsFormPart />} />);
+  //
+  //   const fields = root.find('input');
+  //   const textArea = root.find('textarea');
+  //
+  //   expect(fields.length).toBe(5);
+  //   expect(textArea.length).toBe(1);
+  // });
 });
 
 xdescribe('AdditionalOptionsFormPart ::', () => {
-  it('should render correct for PostgreSQL instance', async () => {
-    const type = Databases.postgresql;
-    const remoteInstanceCredentials = {
-      isRDS: false,
-    };
-
-    const root = await getMount(
-      <Form
-        onSubmit={jest.fn()}
-        render={() => (
-          <AdditionalOptionsFormPart
-            instanceType={type}
-            remoteInstanceCredentials={remoteInstanceCredentials}
-            loading={false}
-            form={(form as unknown) as FormApi}
-          />
-        )}
-      />
-    );
-
-    expect(root.find('input[name="skip_connection_check"]').length).toBe(1);
-    expect(root.find('input[name="tls"]').length).toBe(1);
-    expect(root.find('input[name="tls_skip_verify"]').length).toBe(1);
-  });
+  // it('should render correct for PostgreSQL instance', async () => {
+  //   const type = Databases.postgresql;
+  //   const remoteInstanceCredentials = {
+  //     isRDS: false,
+  //   };
+  //
+  //   const root = await getMount(
+  //     <Form
+  //       onSubmit={jest.fn()}
+  //       render={() => (
+  //         <AdditionalOptionsFormPart
+  //           instanceType={type}
+  //           remoteInstanceCredentials={remoteInstanceCredentials}
+  //           loading={false}
+  //           form={(form as unknown) as FormApi}
+  //         />
+  //       )}
+  //     />
+  //   );
+  //
+  //   expect(root.find('input[name="skip_connection_check"]').length).toBe(1);
+  //   expect(root.find('input[name="tls"]').length).toBe(1);
+  //   expect(root.find('input[name="tls_skip_verify"]').length).toBe(1);
+  // });
 });
 
 xdescribe('getAdditionalOptions ::', () => {

--- a/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/FormParts.test.tsx
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/FormParts.test.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
 import { Form } from 'react-final-form';
 import { render, screen } from '@testing-library/react';
-// import { FormApi, FormState } from 'final-form';
-// import { trackingOptions } from './FormParts.constants';
-// import { AdditionalOptionsFormPart, getAdditionalOptions } from './AdditionalOptions/AdditionalOptions';
-// import { LabelsFormPart } from './Labels/Labels';
+import { FormApi, FormState } from 'final-form';
+import { trackingOptions, rdsTrackingOptions } from './FormParts.constants';
+import { AdditionalOptionsFormPart, getAdditionalOptions } from './AdditionalOptions/AdditionalOptions';
+import { LabelsFormPart } from './Labels/Labels';
 import { MainDetailsFormPart } from './MainDetails/MainDetails';
 import { ExternalServiceConnectionDetails } from './ExternalServiceConnectionDetails/ExternalServiceConnectionDetails';
-import { getMount } from 'app/percona/shared/helpers/testUtils';
 import { Databases } from 'app/percona/shared/core';
-import { dataTestId } from '@percona/platform-core';
 
-// const form: Partial<FormApi> = {
-//   change: jest.fn(),
-//   getState: () => ({} as FormState<any>),
-// };
+const form: Partial<FormApi> = {
+  change: jest.fn(),
+  getState: () => ({} as FormState<any>),
+};
 
 describe('MainDetailsFormPart ::', () => {
   it('should disable fields with sat isRDS flag', async () => {
@@ -29,160 +27,175 @@ describe('MainDetailsFormPart ::', () => {
     expect(fields.length).toBe(5);
 
     expect(screen.getByTestId('address-text-input')).toBeDisabled();
-    // expect(root.find('input[name="address"]').prop('disabled')).toBeTruthy();
-    // expect(root.find('input[name="serviceName"]').prop('disabled')).toBeFalsy();
-    // expect(root.find('input[name="port"]').prop('disabled')).toBeFalsy();
-    // expect(root.find('input[name="username"]').prop('disabled')).toBeFalsy();
-    // expect(root.find('input[name="password"]').prop('disabled')).toBeFalsy();
+    expect(screen.getByTestId('serviceName-text-input')).not.toBeDisabled();
+    expect(screen.getByTestId('port-text-input')).not.toBeDisabled();
+    expect(screen.getByTestId('username-text-input')).not.toBeDisabled();
+    expect(screen.getByTestId('password-password-input')).not.toBeDisabled();
   });
 
-  // it('should disable fields with not sat isRDS flag', async () => {
-  //   const root = mount(
-  //     <Form
-  //       onSubmit={jest.fn()}
-  //       render={({ form }) => <MainDetailsFormPart form={form} remoteInstanceCredentials={{ isRDS: false }} />}
-  //     />
-  //   );
-  //
-  //   const fields = root.find('input');
-  //
-  //   expect(fields.length).toBe(5);
-  //   expect(root.find('input[name="address"]').prop('disabled')).toBeFalsy();
-  //   expect(root.find('input[name="serviceName"]').prop('disabled')).toBeFalsy();
-  //   expect(root.find('input[name="port"]').prop('disabled')).toBeFalsy();
-  //   expect(root.find('input[name="username"]').prop('disabled')).toBeFalsy();
-  //   expect(root.find('input[name="password"]').prop('disabled')).toBeFalsy();
-  // });
+  it('should disable fields with not sat isRDS flag', async () => {
+    const { container } = render(
+      <Form
+        onSubmit={jest.fn()}
+        render={({ form }) => <MainDetailsFormPart form={form} remoteInstanceCredentials={{ isRDS: false }} />}
+      />
+    );
+
+    const fields = container.querySelectorAll('input');
+    expect(fields.length).toBe(5);
+
+    expect(screen.getByTestId('address-text-input')).not.toBeDisabled();
+    expect(screen.getByTestId('serviceName-text-input')).not.toBeDisabled();
+    expect(screen.getByTestId('port-text-input')).not.toBeDisabled();
+    expect(screen.getByTestId('username-text-input')).not.toBeDisabled();
+    expect(screen.getByTestId('password-password-input')).not.toBeDisabled();
+  });
 });
 
-xdescribe('ExternalServiceConnectionDetails ::', () => {
-  // it('should render', async () => {
-  //   const root = mount(
-  //     <Form
-  //       onSubmit={jest.fn()}
-  //       render={() => <ExternalServiceConnectionDetails form={(form as unknown) as FormApi} />}
-  //     />
-  //   );
-  //
-  //   const fields = root.find('input');
-  //
-  //   expect(fields.length).toBe(5);
-  // });
+describe('ExternalServiceConnectionDetails ::', () => {
+  it('should render', async () => {
+    const { container } = render(
+      <Form
+        onSubmit={jest.fn()}
+        render={() => <ExternalServiceConnectionDetails form={(form as unknown) as FormApi} />}
+      />
+    );
+
+    const fields = container.querySelectorAll('input');
+    expect(fields.length).toBe(5);
+  });
 });
 
-xdescribe('LabelsFormPart ::', () => {
-  // it('should render correct fields with empty props', async () => {
-  //   const root = mount(<Form onSubmit={jest.fn()} render={() => <LabelsFormPart />} />);
-  //
-  //   const fields = root.find('input');
-  //   const textArea = root.find('textarea');
-  //
-  //   expect(fields.length).toBe(5);
-  //   expect(textArea.length).toBe(1);
-  // });
+describe('LabelsFormPart ::', () => {
+  it('should render correct fields with empty props', async () => {
+    const { container } = render(<Form onSubmit={jest.fn()} render={() => <LabelsFormPart />} />);
+
+    const fields = container.querySelectorAll('input');
+    const textArea = container.querySelectorAll('textarea');
+
+    expect(fields.length).toBe(5);
+    expect(textArea.length).toBe(1);
+  });
 });
 
-xdescribe('AdditionalOptionsFormPart ::', () => {
-  // it('should render correct for PostgreSQL instance', async () => {
-  //   const type = Databases.postgresql;
-  //   const remoteInstanceCredentials = {
-  //     isRDS: false,
-  //   };
-  //
-  //   const root = await getMount(
-  //     <Form
-  //       onSubmit={jest.fn()}
-  //       render={() => (
-  //         <AdditionalOptionsFormPart
-  //           instanceType={type}
-  //           remoteInstanceCredentials={remoteInstanceCredentials}
-  //           loading={false}
-  //           form={(form as unknown) as FormApi}
-  //         />
-  //       )}
-  //     />
-  //   );
-  //
-  //   expect(root.find('input[name="skip_connection_check"]').length).toBe(1);
-  //   expect(root.find('input[name="tls"]').length).toBe(1);
-  //   expect(root.find('input[name="tls_skip_verify"]').length).toBe(1);
-  // });
+describe('AdditionalOptionsFormPart ::', () => {
+  it('should render correct for PostgreSQL instance', async () => {
+    const type = Databases.postgresql;
+    const remoteInstanceCredentials = {
+      isRDS: false,
+    };
+
+    render(
+      <Form
+        onSubmit={jest.fn()}
+        render={() => (
+          <AdditionalOptionsFormPart
+            instanceType={type}
+            remoteInstanceCredentials={remoteInstanceCredentials}
+            loading={false}
+            form={(form as unknown) as FormApi}
+          />
+        )}
+      />
+    );
+
+    expect(screen.getByTestId('skip_connection_check-checkbox-input')).toBeInTheDocument();
+    expect(screen.getByTestId('tls-checkbox-input')).toBeInTheDocument();
+    expect(screen.getByTestId('tls_skip_verify-checkbox-input')).toBeInTheDocument();
+  });
 });
 
-xdescribe('getAdditionalOptions ::', () => {
+describe('getAdditionalOptions ::', () => {
   it('should render correct for MongoDB', async () => {
     const type = Databases.mongodb;
     const remoteInstanceCredentials = {
       isRDS: false,
     };
 
-    const root = await getMount(
+    const { container } = render(
       <Form
         onSubmit={jest.fn()}
         render={() => getAdditionalOptions(type, remoteInstanceCredentials, form as FormApi)}
       />
     );
-    const fields = root.find('input');
+    const fields = container.querySelectorAll('input');
 
-    expect(root.find(dataTestId('qan-mongodb-profiler-checkbox')).length).toBe(1);
-    expect(root.find(dataTestId('disable-collectors-input-field')).length).toBe(1);
-    expect(root.find(dataTestId('collections-limit-input-field')).length).toBe(1);
-    expect(root.find(dataTestId('stats_collections-input-field')).length).toBe(1);
-    expect(fields.length).toBe(3);
+    expect(screen.getByTestId('tls-checkbox-input')).toBeInTheDocument();
+    expect(screen.getByTestId('tls_skip_verify-checkbox-input')).toBeInTheDocument();
+    expect(screen.getByTestId('qan_mongodb_profiler-checkbox-input')).toBeInTheDocument();
+    expect(screen.getByTestId('disable_collectors-text-input')).toBeInTheDocument();
+    expect(screen.getByTestId('collections_limit-number-input')).toBeInTheDocument();
+    expect(screen.getByTestId('stats_collections-text-input')).toBeInTheDocument();
+
+    expect(fields.length).toBe(6);
   });
-
   it('should render correct for MySQL', async () => {
     const type = Databases.mysql;
     const remoteInstanceCredentials = {
       isRDS: false,
     };
 
-    const root = await getMount(
+    const { container } = render(
       <Form
         onSubmit={jest.fn()}
         render={() => getAdditionalOptions(type, remoteInstanceCredentials, form as FormApi)}
       />
     );
-    const fields = root.find('input');
+    const fields = container.querySelectorAll('input');
 
-    expect(root.find('input[name="qan_mysql_perfschema"]').length).toBe(1);
+    expect(screen.getByTestId('qan_mysql_perfschema-checkbox-input')).toBeInTheDocument();
     expect(fields.length).toBe(8);
   });
-
   it('should render correct for RDS MySQL', async () => {
     const type = Databases.mysql;
     const remoteInstanceCredentials = {
       isRDS: true,
     };
 
-    const root = await getMount(
+    const { container } = render(
       <Form
         onSubmit={jest.fn()}
         render={() => getAdditionalOptions(type, remoteInstanceCredentials, form as FormApi)}
       />
     );
-    const fields = root.find('input');
-    expect(root.find('input[name="qan_mysql_perfschema"]').length).toBe(1);
-    expect(root.find('input[name="disable_basic_metrics"]').length).toBe(1);
-    expect(root.find('input[name="disable_enhanced_metrics"]').length).toBe(1);
+    const fields = container.querySelectorAll('input');
+    expect(screen.getByTestId('qan_mysql_perfschema-checkbox-input')).toBeInTheDocument();
+    expect(screen.getByTestId('disable_basic_metrics-checkbox-input')).toBeInTheDocument();
+    expect(screen.getByTestId('disable_enhanced_metrics-checkbox-input')).toBeInTheDocument();
     expect(fields.length).toBe(10);
   });
-
   it('should render correct for PostgreSQL', async () => {
+    const type = Databases.postgresql;
+    const remoteInstanceCredentials = {
+      isRDS: false,
+    };
+
+    const { container } = render(
+      <Form
+        onSubmit={jest.fn()}
+        render={() => getAdditionalOptions(type, remoteInstanceCredentials, form as FormApi)}
+      />
+    );
+    const fields = container.querySelectorAll('input');
+    const trakingFields = screen.getAllByTestId('tracking-radio-button');
+    expect(trakingFields.length).toBe(trackingOptions.length);
+    expect(fields.length).toBe(6);
+  });
+  it('should render correct for RDS PostgreSQL', async () => {
     const type = Databases.postgresql;
     const remoteInstanceCredentials = {
       isRDS: true,
     };
 
-    const root = await getMount(
+    const { container } = render(
       <Form
         onSubmit={jest.fn()}
         render={() => getAdditionalOptions(type, remoteInstanceCredentials, form as FormApi)}
       />
     );
-    const fields = root.find('input');
-
-    expect(root.find('input[name="tracking"]').length).toBe(trackingOptions.length);
+    const fields = container.querySelectorAll('input');
+    const trakingFields = screen.getAllByTestId('tracking-radio-button');
+    expect(trakingFields.length).toBe(rdsTrackingOptions.length);
     expect(fields.length).toBe(7);
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
On the Grafana dashboard to add a new instance in Inventory, the AWS entry is misleading. It highlights that only MySQL is supported for RDS or Aurora.
Moreover, current documentation acknowledges the fact that Postgres is supported on AWS RDS.
![image](https://user-images.githubusercontent.com/90199600/145414095-4a14483f-0c4c-4902-a083-2f4c7d4f7d54.png)



**Which issue(s) this PR fixes**:
https://jira.percona.com/browse/PMM-9144