### PR TITLE
PMM-9050 accept config values with equals in them

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -570,13 +570,13 @@ func getCommandLineProperties(args []string) map[string]string {
 		}
 
 		trimmed := strings.TrimPrefix(arg, "cfg:")
-		parts := strings.Split(trimmed, "=")
-		if len(parts) != 2 {
+		equalsIndex := strings.Index(trimmed, "=")
+		if equalsIndex < 0 {
 			log.Fatalf(3, "Invalid command line argument. argument: %v", arg)
 			return nil
 		}
 
-		props[parts[0]] = parts[1]
+		props[trimmed[:equalsIndex]] = trimmed[equalsIndex+1:]
 	}
 	return props
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -575,8 +575,11 @@ func getCommandLineProperties(args []string) map[string]string {
 			log.Fatalf(3, "Invalid command line argument. argument: %v", arg)
 			return nil
 		}
-
-		props[trimmed[:equalsIndex]] = trimmed[equalsIndex+1:]
+		if equalsIndex != len(trimmed)-1 {
+			props[trimmed[:equalsIndex]] = trimmed[equalsIndex+1:]
+			continue
+		}
+		props[trimmed[:equalsIndex]] = ""
 	}
 	return props
 }


### PR DESCRIPTION
Equal signs in the value of command line config properties don't crash Grafana anymore.