### PR TITLE
PMM-9289-get-from-browser-address-error: fix hostname to host in getP…

### DIFF
--- a/public/app/percona/settings/components/Advanced/Advanced.tsx
+++ b/public/app/percona/settings/components/Advanced/Advanced.tsx
@@ -247,7 +247,7 @@ export const Advanced: FC<AdvancedProps> = ({
                   type="button"
                   variant="secondary"
                   data-testid="public-address-button"
-                  onClick={() => change('publicAddress', window.location.hostname)}
+                  onClick={() => change('publicAddress', window.location.host)}
                 >
                   <Icon name="link" />
                   {publicAddressButton}


### PR DESCRIPTION
**What this PR does / why we need it**:
Incorrect Host detection in PMM causes the wrong URL used in  SSO and other features like DBaaS 
![image](https://user-images.githubusercontent.com/90199600/146147061-1b2bab09-d4a7-425e-b9b7-40c40d1a3de5.png)


**Which issue(s) this PR fixes**:
https://jira.percona.com/browse/PMM-9289