### PR TITLE
PMM-9317-add-dbstats-topmetrics-as-the-default-value: add default val…

### DIFF
--- a/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/AdditionalOptions/AdditionalOptions.tsx
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/AdditionalOptions/AdditionalOptions.tsx
@@ -175,6 +175,7 @@ export const getAdditionalOptions = (
             label={Messages.form.labels.additionalOptions.disableCollectors}
             placeholder={Messages.form.placeholders.additionalOptions.disableCollectors}
             validators={[noSymbolsValidator]}
+            defaultValue={'dbstats,topmetrics'}
           />
           <TextInputField
             name="stats_collections"

--- a/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/FormParts.test.tsx
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/FormParts/FormParts.test.tsx
@@ -127,6 +127,11 @@ describe('getAdditionalOptions ::', () => {
     expect(screen.getByTestId('collections_limit-number-input')).toBeInTheDocument();
     expect(screen.getByTestId('stats_collections-text-input')).toBeInTheDocument();
 
+    expect((screen.getByTestId('collections_limit-number-input') as HTMLInputElement).defaultValue).toBe('100');
+    expect((screen.getByTestId('disable_collectors-text-input') as HTMLInputElement).defaultValue).toBe(
+      'dbstats,topmetrics'
+    );
+
     expect(fields.length).toBe(6);
   });
   it('should render correct for MySQL', async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the disabled collectors field to have dbstats,topmetrics as the default value
Problem: User cannot get metrics from collStats and indexStats collectors

![image](https://user-images.githubusercontent.com/90199600/146395619-7226a898-b7b9-4fe3-8643-4f161347be63.png)


**Which issue(s) this PR fixes**:
https://jira.percona.com/browse/PMM-9317
