### PR TITLE
PMM-8535 Stop resources request

### DIFF
--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/DBClusterAdvancedOptions/DBClusterAdvancedOptions.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/DBClusterAdvancedOptions/DBClusterAdvancedOptions.tsx
@@ -40,6 +40,7 @@ export const DBClusterAdvancedOptions: FC<FormRenderProps> = ({ values, form }) 
   const [loadingAllocatedResources, setLoadingAllocatedResources] = useState(false);
   const [expectedResources, setExpectedResources] = useState<DBClusterExpectedResources>();
   const [loadingExpectedResources, setLoadingExpectedResources] = useState(false);
+  const mounted = { current: true };
   const { required, min } = validators;
   const { change } = form;
   const diskValidators = [required, min(MIN_DISK_SIZE)];
@@ -82,7 +83,10 @@ export const DBClusterAdvancedOptions: FC<FormRenderProps> = ({ values, form }) 
         setLoadingAllocatedResources(false);
       }
 
-      allocatedTimer = setTimeout(() => getAllocatedResources(false), RECHECK_INTERVAL);
+      // don't schedule another request if the component was unmounted while the previous request was occuring
+      if (mounted.current) {
+        allocatedTimer = setTimeout(() => getAllocatedResources(false), RECHECK_INTERVAL);
+      }
     }
   };
 
@@ -134,7 +138,10 @@ export const DBClusterAdvancedOptions: FC<FormRenderProps> = ({ values, form }) 
       getAllocatedResources();
     }
 
-    return () => clearTimeout(allocatedTimer);
+    return () => {
+      mounted.current = false;
+      clearTimeout(allocatedTimer);
+    };
   }, [kubernetesCluster]);
 
   useEffect(() => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/master/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the master branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Stops scheduling more resources requests after the component unmounts.
Tried to cancel the request but even if canceled the next one gets scheduled, in order to prevent that we need to store if the component is mounted or not. (not using a ref here because the value needs to be set to true every time the component renders, just using a standard reference)

**Which issue(s) this PR fixes**: https://jira.percona.com/browse/PMM-8535

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
