### PR TITLE
PMM-9485 change run db checks popup message

### DIFF
--- a/public/app/percona/check/components/FailedChecksTab/FailedChecksTab.messages.ts
+++ b/public/app/percona/check/components/FailedChecksTab/FailedChecksTab.messages.ts
@@ -1,4 +1,5 @@
 export const Messages = {
   runDbChecks: 'Run DB checks',
   showAll: 'Show all',
+  checksExecutionStarted: 'Running database checks in the background... The results will be displayed here soon.',
 };

--- a/public/app/percona/check/components/FailedChecksTab/FailedChecksTab.tsx
+++ b/public/app/percona/check/components/FailedChecksTab/FailedChecksTab.tsx
@@ -45,15 +45,12 @@ export const FailedChecksTab: FC = () => {
     setRunChecksPending(true);
     try {
       await CheckService.runDbChecks();
+      appEvents.emit(AppEvents.alertSuccess, [Messages.checksExecutionStarted]);
     } catch (e) {
       logger.error(e);
-    }
-    // TODO (nicolalamacchia): remove this timeout when the API will become synchronous
-    setTimeout(async () => {
+    } finally {
       setRunChecksPending(false);
-      await fetchAlerts();
-      appEvents.emit(AppEvents.alertSuccess, ['Done running DB checks. The latest results are displayed.']);
-    }, 10000);
+    }
   };
 
   const toggleShowSilenced = () => {


### PR DESCRIPTION
**What this PR does / why we need it**: This PR removes 10 seconds delay before showing a pop-up message when the user runs DB checks. Also, the message is adjusted according to the changes on a BE

**Which issue(s) this PR fixes**:
https://jira.percona.com/browse/PMM-9485

Fixes #

**Special notes for your reviewer**:

**FB**: https://github.com/Percona-Lab/pmm-submodules/pull/2282
