### PR TITLE
PMM-10349 DBaaS easy access to deploy button

### DIFF
--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.test.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.test.tsx
@@ -46,6 +46,7 @@ describe('AddDBClusterModal::', () => {
             isVisible
             setVisible={setVisibleStub}
             onSubmit={onDBClusterAddedStub}
+            preSelectedKubernetesCluster={null}
           />
         </Router>
       </Provider>
@@ -78,6 +79,7 @@ describe('AddDBClusterModal::', () => {
             isVisible
             setVisible={setVisibleStub}
             onSubmit={onDBClusterAddedStub}
+            preSelectedKubernetesCluster={null}
           />
         </Router>
       </Provider>
@@ -105,6 +107,7 @@ describe('AddDBClusterModal::', () => {
             isVisible
             setVisible={setVisibleStub}
             onSubmit={onDBClusterAddedStub}
+            preSelectedKubernetesCluster={null}
           />
         </Router>
       </Provider>
@@ -132,6 +135,7 @@ describe('AddDBClusterModal::', () => {
             isVisible
             setVisible={setVisibleStub}
             onSubmit={onDBClusterAddedStub}
+            preSelectedKubernetesCluster={null}
           />
         </Router>
       </Provider>

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.test.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.test.tsx
@@ -9,6 +9,8 @@ import { configureStore } from 'app/store/configureStore';
 import { Router } from 'react-router-dom';
 import { locationService } from '@grafana/runtime';
 import { updateDatabaseClusterNameInitialValue } from './AddDBClusterModal.utils';
+import { KubernetesOperatorStatus } from '../../Kubernetes/OperatorStatusItem/KubernetesOperatorStatus/KubernetesOperatorStatus.types';
+import { KubernetesClusterStatus } from '../../Kubernetes/KubernetesClusterStatus/KubernetesClusterStatus.types';
 
 jest.mock('./AddDBClusterModal.utils', () => ({
   ...jest.requireActual('./AddDBClusterModal.utils'),
@@ -146,6 +148,56 @@ describe('AddDBClusterModal::', () => {
         databaseType: expect.objectContaining({ value: 'mongodb' }),
         kubernetesCluster: expect.objectContaining({
           value: 'Cluster 1',
+        }),
+        name: expect.stringContaining('mongodb-'),
+      })
+    );
+  });
+
+  it('form should have default values from preselectedCluster', () => {
+    const preSelectedCluster = {
+      kubernetesClusterName: 'testPreselectedCluster',
+      operators: {
+        psmdb: {
+          availableVersion: '1.12.0',
+          status: KubernetesOperatorStatus.ok,
+          version: '1.11.0',
+        },
+        pxc: {
+          availableVersion: undefined,
+          status: KubernetesOperatorStatus.ok,
+          version: '1.11.0',
+        },
+      },
+      status: KubernetesClusterStatus.ok,
+    };
+
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: true },
+            settings: { loading: false, result: { isConnectedToPortal: true, alertingEnabled: true } },
+          },
+        } as StoreState)}
+      >
+        <Router history={locationService.getHistory()}>
+          <AddDBClusterModal
+            kubernetes={kubernetesStub}
+            isVisible
+            setVisible={setVisibleStub}
+            onSubmit={onDBClusterAddedStub}
+            preSelectedKubernetesCluster={preSelectedCluster}
+          />
+        </Router>
+      </Provider>
+    );
+
+    expect(updateDatabaseClusterNameInitialValue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databaseType: expect.objectContaining({ value: 'mongodb' }),
+        kubernetesCluster: expect.objectContaining({
+          value: 'testPreselectedCluster',
         }),
         name: expect.stringContaining('mongodb-'),
       })

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.tsx
@@ -15,12 +15,21 @@ import { getAddDbCluster } from 'app/percona/shared/core/selectors';
 import { useShowPMMAddressWarning } from 'app/percona/shared/components/hooks/showPMMAddressWarning';
 import { getInitialValues, updateDatabaseClusterNameInitialValue } from './AddDBClusterModal.utils';
 
-export const AddDBClusterModal: FC<AddDBClusterModalProps> = ({ kubernetes, isVisible, setVisible, onSubmit }) => {
+export const AddDBClusterModal: FC<AddDBClusterModalProps> = ({
+  kubernetes,
+  isVisible,
+  setVisible,
+  onSubmit,
+  preSelectedKubernetesCluster,
+}) => {
   const styles = useStyles(getStyles);
   const { loading } = useSelector(getAddDbCluster);
   const [showPMMAddressWarning] = useShowPMMAddressWarning();
 
-  const initialValues = useMemo(() => getInitialValues(kubernetes), [kubernetes]);
+  const initialValues = useMemo(() => getInitialValues(kubernetes, preSelectedKubernetesCluster), [
+    kubernetes,
+    preSelectedKubernetesCluster,
+  ]);
   const updatedItialValues = useMemo(
     () => (isVisible ? updateDatabaseClusterNameInitialValue(initialValues) : initialValues),
     [initialValues, isVisible]

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.tsx
@@ -30,6 +30,7 @@ export const AddDBClusterModal: FC<AddDBClusterModalProps> = ({
     kubernetes,
     preSelectedKubernetesCluster,
   ]);
+
   const updatedItialValues = useMemo(
     () => (isVisible ? updateDatabaseClusterNameInitialValue(initialValues) : initialValues),
     [initialValues, isVisible]

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.types.ts
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.types.ts
@@ -7,6 +7,7 @@ export interface AddDBClusterModalProps {
   isVisible: boolean;
   setVisible: (value: boolean) => void;
   onSubmit: (values: Record<string, any>, showPMMAddressWarning: boolean) => void;
+  preSelectedKubernetesCluster: Kubernetes | null;
 }
 
 export enum AddDBClusterFields {

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.utils.ts
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.utils.ts
@@ -4,7 +4,10 @@ import { INITIAL_VALUES } from './DBClusterAdvancedOptions/DBClusterAdvancedOpti
 import { getKubernetesOptions } from './DBClusterBasicOptions/DBClusterBasicOptions.utils';
 import { Kubernetes } from '../../Kubernetes/Kubernetes.types';
 
-export const getInitialValues = (kubernetes: Kubernetes[]): AddDbClusterFormValues => {
+export const getInitialValues = (
+  kubernetes: Kubernetes[],
+  preSelectedCluster: Kubernetes | null
+): AddDbClusterFormValues => {
   const activeOperators = getActiveOperators(kubernetes);
 
   const initialValues: AddDbClusterFormValues = {
@@ -16,7 +19,7 @@ export const getInitialValues = (kubernetes: Kubernetes[]): AddDbClusterFormValu
   };
 
   if (kubernetes.length > 0) {
-    const kubernetesOptions = getKubernetesOptions(kubernetes);
+    const kubernetesOptions = getKubernetesOptions(preSelectedCluster ? [preSelectedCluster] : kubernetes);
     const initialCluster = kubernetesOptions.length > 0 && kubernetesOptions[0];
     if (initialCluster) {
       initialValues[AddDBClusterFields.kubernetesCluster] = initialCluster;

--- a/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.utils.ts
+++ b/public/app/percona/dbaas/components/DBCluster/AddDBClusterModal/AddDBClusterModal.utils.ts
@@ -8,7 +8,7 @@ export const getInitialValues = (
   kubernetes: Kubernetes[],
   preSelectedCluster: Kubernetes | null
 ): AddDbClusterFormValues => {
-  const activeOperators = getActiveOperators(kubernetes);
+  const activeOperators = getActiveOperators(preSelectedCluster ? [preSelectedCluster] : kubernetes);
 
   const initialValues: AddDbClusterFormValues = {
     ...INITIAL_VALUES,

--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.test.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.test.tsx
@@ -7,7 +7,16 @@ import { DBCluster } from './DBCluster';
 import { formatDBClusterVersion } from './DBCluster.utils';
 import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { DBClusterStatus } from './DBCluster.types';
+import { KubernetesOperatorStatus } from '../Kubernetes/OperatorStatusItem/KubernetesOperatorStatus/KubernetesOperatorStatus.types';
+import { KubernetesClusterStatus } from '../Kubernetes/KubernetesClusterStatus/KubernetesClusterStatus.types';
+import { locationService } from '@grafana/runtime/src';
+import { Router } from 'react-router-dom';
+import { updateDatabaseClusterNameInitialValue } from './AddDBClusterModal/AddDBClusterModal.utils';
 
+jest.mock('./AddDBClusterModal/AddDBClusterModal.utils', () => ({
+  ...jest.requireActual('./AddDBClusterModal/AddDBClusterModal.utils'),
+  updateDatabaseClusterNameInitialValue: jest.fn(),
+}));
 jest.mock('app/core/app_events');
 jest.mock('app/percona/dbaas/components/Kubernetes/Kubernetes.service');
 jest.mock('@percona/platform-core', () => {
@@ -166,5 +175,65 @@ describe('DBCluster::', () => {
     expect(screen.getAllByRole('cell')[1].textContent).toEqual(
       `${DATABASE_LABELS.mongodb} ${formatDBClusterVersion('percona/percona-xtra-dbcluster:8.0')}`
     );
+  });
+
+  it('should open AddModal if kubernetesCluster was selected', async () => {
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: true },
+            settings: { loading: false, result: { isConnectedToPortal: true, dbaasEnabled: true } },
+            kubernetes: {
+              loading: false,
+            },
+            dbaas: {
+              selectedKubernetesCluster: {
+                kubernetesClusterName: 'testPreselectedCluster',
+                operators: {
+                  psmdb: {
+                    availableVersion: '1.12.0',
+                    status: KubernetesOperatorStatus.ok,
+                    version: '1.11.0',
+                  },
+                  pxc: {
+                    availableVersion: undefined,
+                    status: KubernetesOperatorStatus.ok,
+                    version: '1.11.0',
+                  },
+                },
+                status: KubernetesClusterStatus.ok,
+              },
+            },
+            addKubernetes: { loading: false },
+            deleteKubernetes: { loading: false },
+            dbClusters: {
+              loading: false,
+              result: [
+                {
+                  clusterName: 'cluster_1',
+                  kubernetesClusterName: 'cluster_1',
+                  databaseType: 'mongodb',
+                  clusterSize: 1,
+                  memory: 1000,
+                  cpu: 1000,
+                  disk: 1000,
+                  status: DBClusterStatus.failed,
+                  message: 'Error',
+                  installedImage: 'percona/percona-xtra-dbcluster:8.0',
+                },
+              ],
+            },
+          },
+        } as StoreState)}
+      >
+        <Router history={locationService.getHistory()}>
+          <DBCluster />
+        </Router>
+      </Provider>
+    );
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('table-loading'));
+    expect(updateDatabaseClusterNameInitialValue).toHaveBeenCalled();
   });
 });

--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.test.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.test.tsx
@@ -233,7 +233,6 @@ describe('DBCluster::', () => {
       </Provider>
     );
 
-    await waitForElementToBeRemoved(() => screen.getByTestId('table-loading'));
     expect(updateDatabaseClusterNameInitialValue).toHaveBeenCalled();
   });
 });

--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
@@ -6,7 +6,12 @@ import Page from 'app/core/components/Page/Page';
 import { FeatureLoader } from 'app/percona/shared/components/Elements/FeatureLoader';
 import { TechnicalPreview } from 'app/percona/shared/components/Elements/TechnicalPreview/TechnicalPreview';
 import { Table } from 'app/percona/shared/components/Elements/Table';
-import { getKubernetes, getPerconaDBClusters, getPerconaSettingFlag } from 'app/percona/shared/core/selectors';
+import {
+  getDBaaS,
+  getKubernetes,
+  getPerconaDBClusters,
+  getPerconaSettingFlag,
+} from 'app/percona/shared/core/selectors';
 import { Messages } from 'app/percona/dbaas/DBaaS.messages';
 import { AddClusterButton } from '../AddClusterButton/AddClusterButton';
 import { getStyles } from './DBCluster.styles';
@@ -37,12 +42,13 @@ import { logger } from '@sentry/utils';
 
 export const DBCluster: FC = () => {
   const styles = useStyles(getStyles);
-  const [addModalVisible, setAddModalVisible] = useState(false);
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
   const [editModalVisible, setEditModalVisible] = useState(false);
   const [logsModalVisible, setLogsModalVisible] = useState(false);
   const [updateModalVisible, setUpdateModalVisible] = useState(false);
   const [selectedCluster, setSelectedCluster] = useState<Cluster>();
+  const { selectedKubernetesCluster } = useSelector(getDBaaS);
+  const [addModalVisible, setAddModalVisible] = useState(selectedKubernetesCluster ? true : false);
   const navModel = usePerconaNavModel('dbclusters');
   const dispatch = useAppDispatch();
   const [generateToken] = useCancelToken();
@@ -201,6 +207,7 @@ export const DBCluster: FC = () => {
               isVisible={addModalVisible}
               setVisible={setAddModalVisible}
               onSubmit={addCluster}
+              preSelectedKubernetesCluster={selectedKubernetesCluster}
             />
             <DeleteDBClusterModal
               isVisible={deleteModalVisible}

--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
@@ -164,12 +164,14 @@ export const DBCluster: FC = () => {
   const featureSelector = useCallback(getPerconaSettingFlag('dbaasEnabled'), []);
 
   useEffect(() => {
-    dispatch(
-      fetchKubernetesAction({
-        kubernetes: generateToken(GET_KUBERNETES_CANCEL_TOKEN),
-        operator: generateToken(CHECK_OPERATOR_UPDATE_CANCEL_TOKEN),
-      })
-    );
+    if (!selectedKubernetesCluster) {
+      dispatch(
+        fetchKubernetesAction({
+          kubernetes: generateToken(GET_KUBERNETES_CANCEL_TOKEN),
+          operator: generateToken(CHECK_OPERATOR_UPDATE_CANCEL_TOKEN),
+        })
+      );
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
@@ -29,7 +29,12 @@ import {
 } from './ColumnRenderers/ColumnRenderers';
 import { DeleteDBClusterModal } from './DeleteDBClusterModal/DeleteDBClusterModal';
 import { UpdateDBClusterModal } from './UpdateDBClusterModal/UpdateDBClusterModal';
-import { addDbClusterAction, fetchDBClustersAction, fetchKubernetesAction } from 'app/percona/shared/core/reducers';
+import {
+  addDbClusterAction,
+  fetchDBClustersAction,
+  fetchKubernetesAction,
+  selectKubernetesCluster,
+} from 'app/percona/shared/core/reducers';
 import { useCatchCancellationError } from 'app/percona/shared/components/hooks/catchCancellationError';
 import { useCancelToken } from 'app/percona/shared/components/hooks/cancelToken.hook';
 import { CHECK_OPERATOR_UPDATE_CANCEL_TOKEN, GET_KUBERNETES_CANCEL_TOKEN } from '../Kubernetes/Kubernetes.constants';
@@ -165,6 +170,13 @@ export const DBCluster: FC = () => {
         operator: generateToken(CHECK_OPERATOR_UPDATE_CANCEL_TOKEN),
       })
     );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      dispatch(selectKubernetesCluster(null));
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
+++ b/public/app/percona/dbaas/components/DBCluster/DBCluster.tsx
@@ -53,7 +53,7 @@ export const DBCluster: FC = () => {
   const [updateModalVisible, setUpdateModalVisible] = useState(false);
   const [selectedCluster, setSelectedCluster] = useState<Cluster>();
   const { selectedKubernetesCluster } = useSelector(getDBaaS);
-  const [addModalVisible, setAddModalVisible] = useState(selectedKubernetesCluster ? true : false);
+  const [addModalVisible, setAddModalVisible] = useState(!!selectedKubernetesCluster);
   const navModel = usePerconaNavModel('dbclusters');
   const dispatch = useAppDispatch();
   const [generateToken] = useCancelToken();

--- a/public/app/percona/dbaas/components/Kubernetes/KubernetesInventory.tsx
+++ b/public/app/percona/dbaas/components/Kubernetes/KubernetesInventory.tsx
@@ -82,7 +82,7 @@ export const KubernetesInventory: FC = () => {
             element={element}
             setSelectedCluster={setSelectedCluster}
             setOperatorToUpdate={setOperatorToUpdate}
-            setUpdateOperatorModalVisible={setAddModalVisible}
+            setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}
           />
         ),
       },

--- a/public/app/percona/dbaas/components/Kubernetes/KubernetesInventory.tsx
+++ b/public/app/percona/dbaas/components/Kubernetes/KubernetesInventory.tsx
@@ -19,11 +19,9 @@ import { useCancelToken } from 'app/percona/shared/components/hooks/cancelToken.
 import { Table } from 'app/percona/shared/components/Elements/Table/Table';
 import { Messages } from 'app/percona/dbaas/DBaaS.messages';
 import { Form } from 'react-final-form';
-import { Databases } from 'app/percona/shared/core';
 import { getStyles } from './Kubernetes.styles';
 import { Kubernetes, OperatorToUpdate, NewKubernetesCluster } from './Kubernetes.types';
 import { AddClusterButton } from '../AddClusterButton/AddClusterButton';
-import { OperatorStatusItem } from './OperatorStatusItem/OperatorStatusItem';
 import { KubernetesClusterStatus } from './KubernetesClusterStatus/KubernetesClusterStatus';
 import { clusterActionsRender } from './ColumnRenderers/ColumnRenderers';
 import { ViewClusterConfigModal } from './ViewClusterConfigModal/ViewClusterConfigModal';
@@ -36,7 +34,7 @@ import {
   DELETE_KUBERNETES_CANCEL_TOKEN,
 } from './Kubernetes.constants';
 import { PortalK8sFreeClusterPromotingMessage } from './PortalK8sFreeClusterPromotingMessage/PortalK8sFreeClusterPromotingMessage';
-// import { OperatorStatusRow } from './OperatorStatusRow/OperatorStatusRow';
+import { OperatorStatusRow } from './OperatorStatusRow/OperatorStatusRow';
 
 export const KubernetesInventory: FC = () => {
   const styles = useStyles(getStyles);
@@ -80,25 +78,12 @@ export const KubernetesInventory: FC = () => {
       {
         Header: Messages.kubernetes.table.operatorsColumn,
         accessor: (element: Kubernetes) => (
-          <div>
-            <OperatorStatusItem
-              databaseType={Databases.mysql}
-              operator={element.operators.pxc}
-              kubernetes={element}
-              setSelectedCluster={setSelectedCluster}
-              setOperatorToUpdate={setOperatorToUpdate}
-              setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}
-            />
-            <OperatorStatusItem
-              databaseType={Databases.mongodb}
-              operator={element.operators.psmdb}
-              kubernetes={element}
-              setSelectedCluster={setSelectedCluster}
-              setOperatorToUpdate={setOperatorToUpdate}
-              setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}
-            />
-          </div>
-          // <OperatorStatusRow kubernetes={kubernetes} kubernetesLoading={kubernetesLoading} element={element} />
+          <OperatorStatusRow
+            element={element}
+            setSelectedCluster={setSelectedCluster}
+            setOperatorToUpdate={setOperatorToUpdate}
+            setUpdateOperatorModalVisible={setAddModalVisible}
+          />
         ),
       },
       {

--- a/public/app/percona/dbaas/components/Kubernetes/KubernetesInventory.tsx
+++ b/public/app/percona/dbaas/components/Kubernetes/KubernetesInventory.tsx
@@ -36,6 +36,7 @@ import {
   DELETE_KUBERNETES_CANCEL_TOKEN,
 } from './Kubernetes.constants';
 import { PortalK8sFreeClusterPromotingMessage } from './PortalK8sFreeClusterPromotingMessage/PortalK8sFreeClusterPromotingMessage';
+// import { OperatorStatusRow } from './OperatorStatusRow/OperatorStatusRow';
 
 export const KubernetesInventory: FC = () => {
   const styles = useStyles(getStyles);
@@ -97,6 +98,7 @@ export const KubernetesInventory: FC = () => {
               setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}
             />
           </div>
+          // <OperatorStatusRow kubernetes={kubernetes} kubernetesLoading={kubernetesLoading} element={element} />
         ),
       },
       {

--- a/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.styles.ts
+++ b/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.styles.ts
@@ -4,5 +4,7 @@ import { GrafanaTheme } from '@grafana/data';
 export const getStyles = ({ spacing }: GrafanaTheme) => ({
   operatorRowWrapper: css`
     display: flex;
+    align-items: center;
+    justify-content: space-between;
   `,
 });

--- a/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.styles.ts
+++ b/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.styles.ts
@@ -1,0 +1,8 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme } from '@grafana/data';
+
+export const getStyles = ({ spacing }: GrafanaTheme) => ({
+  operatorRowWrapper: css`
+    display: flex;
+  `,
+});

--- a/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.test.tsx
+++ b/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { OperatorStatusRow } from './OperatorStatusRow';
+import { KubernetesClusterStatus } from '../KubernetesClusterStatus/KubernetesClusterStatus.types';
+import { KubernetesOperatorStatus } from '../OperatorStatusItem/KubernetesOperatorStatus/KubernetesOperatorStatus.types';
+import { configureStore } from '../../../../../store/configureStore';
+import { StoreState } from '../../../../../types';
+import { Provider } from 'react-redux';
+
+jest.mock('app/core/app_events');
+jest.mock('app/percona/dbaas/components/Kubernetes/Kubernetes.service');
+
+describe('OperatorStatusRow::', () => {
+  it('createDBCluster button should be disabled when kubernetesClusterStatus is invalid', async () => {
+    const element = {
+      kubernetesClusterName: 'cluster1',
+      status: KubernetesClusterStatus.invalid,
+      operators: {
+        psmdb: { status: KubernetesOperatorStatus.ok, version: '1', availableVersion: '1' },
+        pxc: { status: KubernetesOperatorStatus.ok, version: '1', availableVersion: '1' },
+      },
+    };
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: true },
+            settings: { loading: false, result: { isConnectedToPortal: true, dbaasEnabled: true } },
+          },
+        } as StoreState)}
+      >
+        <OperatorStatusRow
+          element={element}
+          setSelectedCluster={jest.fn}
+          setOperatorToUpdate={jest.fn}
+          setUpdateOperatorModalVisible={jest.fn}
+        />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('cluster1-add-cluster-button')).toBeDisabled();
+  });
+
+  it('createDBCluster button should be disabled when kubernetesClusterStatus is unavailable', async () => {
+    const element = {
+      kubernetesClusterName: 'cluster1',
+      status: KubernetesClusterStatus.unavailable,
+      operators: {
+        psmdb: { status: KubernetesOperatorStatus.ok, version: '1', availableVersion: '1' },
+        pxc: { status: KubernetesOperatorStatus.ok, version: '1', availableVersion: '1' },
+      },
+    };
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: true },
+            settings: { loading: false, result: { isConnectedToPortal: true, dbaasEnabled: true } },
+          },
+        } as StoreState)}
+      >
+        <OperatorStatusRow
+          element={element}
+          setSelectedCluster={jest.fn}
+          setOperatorToUpdate={jest.fn}
+          setUpdateOperatorModalVisible={jest.fn}
+        />
+      </Provider>
+    );
+    expect(screen.getByTestId('cluster1-add-cluster-button')).toBeDisabled();
+  });
+
+  it('createDBCluster button should be disabled when both operators are not ok', async () => {
+    const element = {
+      kubernetesClusterName: 'cluster1',
+      status: KubernetesClusterStatus.ok,
+      operators: {
+        psmdb: { status: KubernetesOperatorStatus.invalid, version: '1', availableVersion: '1' },
+        pxc: { status: KubernetesOperatorStatus.unsupported, version: '1', availableVersion: '1' },
+      },
+    };
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: true },
+            settings: { loading: false, result: { isConnectedToPortal: true, dbaasEnabled: true } },
+          },
+        } as StoreState)}
+      >
+        <OperatorStatusRow
+          element={element}
+          setSelectedCluster={jest.fn}
+          setOperatorToUpdate={jest.fn}
+          setUpdateOperatorModalVisible={jest.fn}
+        />
+      </Provider>
+    );
+    expect(screen.getByTestId('cluster1-add-cluster-button')).toBeDisabled();
+  });
+
+  it('createDBCluster button should be disabled when both operators are not ok', async () => {
+    const element = {
+      kubernetesClusterName: 'cluster1',
+      status: KubernetesClusterStatus.ok,
+      operators: {
+        psmdb: { status: KubernetesOperatorStatus.unavailable, version: '1', availableVersion: '1' },
+        pxc: { status: KubernetesOperatorStatus.invalid, version: '1', availableVersion: '1' },
+      },
+    };
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: true },
+            settings: { loading: false, result: { isConnectedToPortal: true, dbaasEnabled: true } },
+          },
+        } as StoreState)}
+      >
+        <OperatorStatusRow
+          element={element}
+          setSelectedCluster={jest.fn}
+          setOperatorToUpdate={jest.fn}
+          setUpdateOperatorModalVisible={jest.fn}
+        />
+      </Provider>
+    );
+    expect(screen.getByTestId('cluster1-add-cluster-button')).toBeDisabled();
+  });
+
+  it('createDBCluster button should be enabled when clusterStatus and operatorStatus have ok status', async () => {
+    const element = {
+      kubernetesClusterName: 'cluster1',
+      status: KubernetesClusterStatus.ok,
+      operators: {
+        psmdb: { status: KubernetesOperatorStatus.ok, version: '1', availableVersion: '1' },
+        pxc: { status: KubernetesOperatorStatus.ok, version: '1', availableVersion: '1' },
+      },
+    };
+    render(
+      <Provider
+        store={configureStore({
+          percona: {
+            user: { isAuthorized: true },
+            settings: { loading: false, result: { isConnectedToPortal: true, dbaasEnabled: true } },
+          },
+        } as StoreState)}
+      >
+        <OperatorStatusRow
+          element={element}
+          setSelectedCluster={jest.fn}
+          setOperatorToUpdate={jest.fn}
+          setUpdateOperatorModalVisible={jest.fn}
+        />
+      </Provider>
+    );
+    expect(screen.getByTestId('cluster1-add-cluster-button')).not.toBeDisabled();
+  });
+});

--- a/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.test.tsx
+++ b/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.test.tsx
@@ -7,9 +7,6 @@ import { configureStore } from '../../../../../store/configureStore';
 import { StoreState } from '../../../../../types';
 import { Provider } from 'react-redux';
 
-jest.mock('app/core/app_events');
-jest.mock('app/percona/dbaas/components/Kubernetes/Kubernetes.service');
-
 describe('OperatorStatusRow::', () => {
   it('createDBCluster button should be disabled when kubernetesClusterStatus is invalid', async () => {
     const element = {

--- a/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.tsx
+++ b/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import { Kubernetes, OperatorToUpdate } from '../Kubernetes.types';
 import { OperatorStatusItem } from '../OperatorStatusItem/OperatorStatusItem';
 import { AddClusterButton } from '../../AddClusterButton/AddClusterButton';
@@ -9,6 +9,8 @@ import { getStyles } from './OperatorStatusRow.styles';
 import { selectKubernetesCluster } from '../../../../shared/core/reducers';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import { KubernetesOperatorStatus } from '../OperatorStatusItem/KubernetesOperatorStatus/KubernetesOperatorStatus.types';
+import { KubernetesClusterStatus } from '../KubernetesClusterStatus/KubernetesClusterStatus.types';
 
 interface OperatorStatusRowProps {
   element: Kubernetes;
@@ -26,6 +28,15 @@ export const OperatorStatusRow: FC<OperatorStatusRowProps> = ({
   const styles = useStyles(getStyles);
   const history = useHistory();
   const dispatch = useDispatch();
+  const isDisabled = useMemo(
+    () =>
+      element.status !== KubernetesClusterStatus.ok ||
+      !(
+        element?.operators?.pxc?.status === KubernetesOperatorStatus.ok ||
+        element?.operators?.psmdb?.status === KubernetesOperatorStatus.ok
+      ),
+    [element]
+  );
 
   return (
     <div data-testid={`${element.kubernetesClusterName}-kubernetes-row-wrapper`} className={styles.operatorRowWrapper}>
@@ -54,6 +65,7 @@ export const OperatorStatusRow: FC<OperatorStatusRowProps> = ({
           history.push('/dbaas/dbclusters');
         }}
         data-testid={`${element.kubernetesClusterName}-add-cluster-button`}
+        disabled={isDisabled}
       />
     </div>
   );

--- a/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.tsx
+++ b/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.tsx
@@ -1,43 +1,60 @@
 import React, { FC } from 'react';
-import { Kubernetes } from '../Kubernetes.types';
+import { Kubernetes, OperatorToUpdate } from '../Kubernetes.types';
+import { OperatorStatusItem } from '../OperatorStatusItem/OperatorStatusItem';
+import { AddClusterButton } from '../../AddClusterButton/AddClusterButton';
+import { Databases } from '../../../../shared/core';
+import { Messages } from 'app/percona/dbaas/DBaaS.messages';
+import { useStyles } from '@grafana/ui/src';
+import { getStyles } from './OperatorStatusRow.styles';
+import { selectKubernetesCluster } from '../../../../shared/core/reducers';
+import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 
 interface OperatorStatusRowProps {
-  kubernetes: Kubernetes[];
-  kubernetesLoading: boolean;
   element: Kubernetes;
+  setSelectedCluster: React.Dispatch<React.SetStateAction<Kubernetes | null>>;
+  setOperatorToUpdate: React.Dispatch<React.SetStateAction<OperatorToUpdate | null>>;
+  setUpdateOperatorModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export const OperatorStatusRow: FC<OperatorStatusRowProps> = ({ kubernetes, element }) => {
-  // const styles = useStyles(getStyles);
-  // const addDisabled = kubernetes.length === 0 || isKubernetesListUnavailable(kubernetes) || loading;
+export const OperatorStatusRow: FC<OperatorStatusRowProps> = ({
+  element,
+  setSelectedCluster,
+  setOperatorToUpdate,
+  setUpdateOperatorModalVisible,
+}) => {
+  const styles = useStyles(getStyles);
+  const history = useHistory();
+  const dispatch = useDispatch();
 
   return (
-    <div data-testid={`${element.kubernetesClusterName}-kubernetes-row-wrapper`}>
+    <div data-testid={`${element.kubernetesClusterName}-kubernetes-row-wrapper`} className={styles.operatorRowWrapper}>
       <div>
-        {/*  <OperatorStatusItem*/}
-        {/*    databaseType={Databases.mysql}*/}
-        {/*    operator={element.operators.pxc}*/}
-        {/*    kubernetes={element}*/}
-        {/*    setSelectedCluster={setSelectedCluster}*/}
-        {/*    setOperatorToUpdate={setOperatorToUpdate}*/}
-        {/*    setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}*/}
-        {/*  />*/}
-        {/*  <OperatorStatusItem*/}
-        {/*    databaseType={Databases.mongodb}*/}
-        {/*    operator={element.operators.psmdb}*/}
-        {/*    kubernetes={element}*/}
-        {/*    setSelectedCluster={setSelectedCluster}*/}
-        {/*    setOperatorToUpdate={setOperatorToUpdate}*/}
-        {/*    setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}*/}
-        {/*  />*/}
-        {/*</div>*/}
-        {/*<AddClusterButton*/}
-        {/*  label={Messages.dbcluster.addAction}*/}
-        {/*  disabled={addDisabled}*/}
-        {/*  action={() => setAddModalVisible(!addModalVisible)}*/}
-        {/*  data-testid="dbcluster-add-cluster-button"*/}
-        {/*/>*/}
+        <OperatorStatusItem
+          databaseType={Databases.mysql}
+          operator={element.operators.pxc}
+          kubernetes={element}
+          setSelectedCluster={setSelectedCluster}
+          setOperatorToUpdate={setOperatorToUpdate}
+          setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}
+        />
+        <OperatorStatusItem
+          databaseType={Databases.mongodb}
+          operator={element.operators.psmdb}
+          kubernetes={element}
+          setSelectedCluster={setSelectedCluster}
+          setOperatorToUpdate={setOperatorToUpdate}
+          setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}
+        />
       </div>
+      <AddClusterButton
+        label={Messages.dbcluster.addAction}
+        action={() => {
+          dispatch(selectKubernetesCluster(element));
+          history.push('/dbaas/dbclusters');
+        }}
+        data-testid={`${element.kubernetesClusterName}-add-cluster-button`}
+      />
     </div>
   );
 };

--- a/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.tsx
+++ b/public/app/percona/dbaas/components/Kubernetes/OperatorStatusRow/OperatorStatusRow.tsx
@@ -1,0 +1,43 @@
+import React, { FC } from 'react';
+import { Kubernetes } from '../Kubernetes.types';
+
+interface OperatorStatusRowProps {
+  kubernetes: Kubernetes[];
+  kubernetesLoading: boolean;
+  element: Kubernetes;
+}
+
+export const OperatorStatusRow: FC<OperatorStatusRowProps> = ({ kubernetes, element }) => {
+  // const styles = useStyles(getStyles);
+  // const addDisabled = kubernetes.length === 0 || isKubernetesListUnavailable(kubernetes) || loading;
+
+  return (
+    <div data-testid={`${element.kubernetesClusterName}-kubernetes-row-wrapper`}>
+      <div>
+        {/*  <OperatorStatusItem*/}
+        {/*    databaseType={Databases.mysql}*/}
+        {/*    operator={element.operators.pxc}*/}
+        {/*    kubernetes={element}*/}
+        {/*    setSelectedCluster={setSelectedCluster}*/}
+        {/*    setOperatorToUpdate={setOperatorToUpdate}*/}
+        {/*    setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}*/}
+        {/*  />*/}
+        {/*  <OperatorStatusItem*/}
+        {/*    databaseType={Databases.mongodb}*/}
+        {/*    operator={element.operators.psmdb}*/}
+        {/*    kubernetes={element}*/}
+        {/*    setSelectedCluster={setSelectedCluster}*/}
+        {/*    setOperatorToUpdate={setOperatorToUpdate}*/}
+        {/*    setUpdateOperatorModalVisible={setUpdateOperatorModalVisible}*/}
+        {/*  />*/}
+        {/*</div>*/}
+        {/*<AddClusterButton*/}
+        {/*  label={Messages.dbcluster.addAction}*/}
+        {/*  disabled={addDisabled}*/}
+        {/*  action={() => setAddModalVisible(!addModalVisible)}*/}
+        {/*  data-testid="dbcluster-add-cluster-button"*/}
+        {/*/>*/}
+      </div>
+    </div>
+  );
+};

--- a/public/app/percona/shared/core/reducers.ts
+++ b/public/app/percona/shared/core/reducers.ts
@@ -280,7 +280,7 @@ const perconaDBaaSSlice = createSlice({
   name: 'perconaDBaaS',
   initialState: initialDBaaSState,
   reducers: {
-    selectKubernetesCluster: (state, action: PayloadAction<Kubernetes>): PerconaDBaaSState => ({
+    selectKubernetesCluster: (state, action: PayloadAction<Kubernetes | null>): PerconaDBaaSState => ({
       ...state,
       selectedKubernetesCluster: action.payload,
     }),

--- a/public/app/percona/shared/core/reducers.ts
+++ b/public/app/percona/shared/core/reducers.ts
@@ -268,6 +268,27 @@ export const addKubernetesAction = createAsyncThunk(
     await thunkAPI.dispatch(fetchKubernetesAction());
   }
 );
+export interface PerconaDBaaSState {
+  selectedKubernetesCluster: Kubernetes | null;
+}
+
+export const initialDBaaSState: PerconaDBaaSState = {
+  selectedKubernetesCluster: null,
+};
+
+const perconaDBaaSSlice = createSlice({
+  name: 'perconaDBaaS',
+  initialState: initialDBaaSState,
+  reducers: {
+    selectKubernetesCluster: (state, action: PayloadAction<Kubernetes>): PerconaDBaaSState => ({
+      ...state,
+      selectedKubernetesCluster: action.payload,
+    }),
+  },
+});
+
+export const { selectKubernetesCluster } = perconaDBaaSSlice.actions;
+export const perconaDBaaSReducers = perconaDBaaSSlice.reducer;
 
 export const addDbClusterAction = createAsyncThunk(
   'percona/addDbCluster',
@@ -409,6 +430,7 @@ export default {
     settings: settingsReducer,
     updateSettings: updateSettingsReducer,
     user: perconaUserReducers,
+    dbaas: perconaDBaaSReducers,
     kubernetes: kubernetesReducer,
     deleteKubernetes: deleteKubernetesReducer,
     addKubernetes: addKubernetesReducer,

--- a/public/app/percona/shared/core/selectors.ts
+++ b/public/app/percona/shared/core/selectors.ts
@@ -5,6 +5,7 @@ export const getPerconaSettings = (state: StoreState) => state.percona.settings;
 export const getPerconaSettingFlag = (setting: keyof Settings) => (state: StoreState) =>
   !!state.percona.settings.result?.[setting];
 export const getPerconaUser = (state: StoreState) => state.percona.user;
+export const getDBaaS = (state: StoreState) => state.percona.dbaas;
 export const getKubernetes = (state: StoreState) => state.percona.kubernetes;
 export const getDeleteKubernetes = (state: StoreState) => state.percona.deleteKubernetes;
 export const getAddKubernetes = (state: StoreState) => state.percona.addKubernetes;


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-10349
To deploy the initial DB Cluster, the user who just configured K8s needs to know about the second tab in UI to test the deployment.  It will be better to give them an easy solution to deploy into just added k8s Cluster 

[Запись встречи 17.08.2022 17-06-45 - запись.webm](https://user-images.githubusercontent.com/90199600/185141991-e2682077-da4d-4300-b2c6-29b61e8a7f2a.webm)

