### PR TITLE
PMM-10587: Set default value for telemetry_summaries endpoint to not break UI if it's empty

### DIFF
--- a/public/app/percona/settings/Settings.service.ts
+++ b/public/app/percona/settings/Settings.service.ts
@@ -33,7 +33,7 @@ const toModel = (response: SettingsPayload): Settings => ({
   awsPartitions: response.aws_partitions,
   updatesDisabled: response.updates_disabled,
   telemetryEnabled: response.telemetry_enabled,
-  telemetrySummaries: response.telemetry_summaries,
+  telemetrySummaries: response.telemetry_summaries || [],
   metricsResolutions: response.metrics_resolutions,
   dataRetention: response.data_retention,
   sshKey: response.ssh_key,


### PR DESCRIPTION
**What this PR does / why we need it:**

**Which issue(s) this PR fixes:**
https://jira.percona.com/browse/PMM-10587