### PR TITLE
PMM-13045 Add RDS assume role field

### DIFF
--- a/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.tools.test.ts
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.tools.test.ts
@@ -40,6 +40,7 @@ describe('Get instance data:: ', () => {
       region: 'us-west1',
       aws_access_key: 'aws-secret-key-example',
       aws_secret_key: 'aws-secret-key-example',
+      aws_role_arn: 'arn:aws:iam::123456789012:role/PmmRdsReadOnlyRole',
       az: 'test az',
     };
     const testInstance = {
@@ -54,6 +55,7 @@ describe('Get instance data:: ', () => {
         region: 'us-west1',
         aws_access_key: 'aws-secret-key-example',
         aws_secret_key: 'aws-secret-key-example',
+        aws_role_arn: 'arn:aws:iam::123456789012:role/PmmRdsReadOnlyRole',
         az: 'test az',
       },
     };

--- a/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.tools.tsx
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.tools.tsx
@@ -65,6 +65,7 @@ const getRDSCredentials = (credentials: any, instanceType: InstanceAvailableType
       region: credentials.region,
       aws_access_key: credentials.aws_access_key,
       aws_secret_key: credentials.aws_secret_key,
+      aws_role_arn: credentials.aws_role_arn,
       instance_id: credentials.instance_id,
       az: credentials.az,
     },

--- a/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.types.ts
+++ b/public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.types.ts
@@ -199,6 +199,7 @@ export interface RDSPayload extends CommonRDSAzurePayload {
   replication_set: string;
   aws_access_key: string;
   aws_secret_key: string;
+  aws_role_arn: string;
   rds_exporter: boolean;
   qan_mysql_perfschema: boolean;
   disable_parsing_comments: boolean;

--- a/public/app/percona/add-instance/components/Discovery/Discovery.constants.ts
+++ b/public/app/percona/add-instance/components/Discovery/Discovery.constants.ts
@@ -1,2 +1,2 @@
 export const DISCOVERY_RDS_CANCEL_TOKEN = 'discoveryRds';
-export const INITIAL_CREDENTIALS = { aws_secret_key: '', aws_access_key: '' };
+export const INITIAL_CREDENTIALS = { aws_secret_key: '', aws_access_key: '', aws_role_arn: '' };

--- a/public/app/percona/add-instance/components/Discovery/Discovery.service.ts
+++ b/public/app/percona/add-instance/components/Discovery/Discovery.service.ts
@@ -12,7 +12,7 @@ const { awsNoCredentialsError, noCredentialsError } = Messages;
 
 class DiscoveryService {
   static async discoveryRDS(
-    { aws_access_key, aws_secret_key }: RDSCredentialsForm,
+    { aws_access_key, aws_secret_key, aws_role_arn }: RDSCredentialsForm,
     token?: CancelToken,
     disableNotifications = false
   ) {
@@ -22,6 +22,7 @@ class DiscoveryService {
         {
           aws_access_key,
           aws_secret_key,
+          aws_role_arn,
         },
         true,
         token

--- a/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.messages.ts
+++ b/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.messages.ts
@@ -11,6 +11,12 @@ export const Messages = {
         name: 'aws_secret_key',
         label: 'Amazon RDS secret key',
       },
+      awsRoleArn: {
+        placeholder: 'arn:aws:iam::123456789012:role/PmmRdsReadOnlyRole',
+        name: 'aws_role_arn',
+        label: 'AWS IAM role ARN',
+        tooltipText: 'Optional. PMM Server assumes this role before discovering RDS instances.',
+      },
     },
     submitButton: 'Discover',
     toMenuButton: 'Return to menu',

--- a/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.styles.ts
+++ b/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.styles.ts
@@ -17,6 +17,11 @@ export const getStyles = ({ breakpoints, spacing }: GrafanaTheme) => {
     `,
     fieldsWrapper: css`
       display: flex;
+      flex-direction: column;
+      width: 100%;
+    `,
+    credentialsRow: css`
+      display: flex;
       width: 100%;
       div {
         width: 100%;
@@ -33,6 +38,9 @@ export const getStyles = ({ breakpoints, spacing }: GrafanaTheme) => {
     `,
     credentialsField: css`
       width: 48%;
+    `,
+    roleArnField: css`
+      width: 100%;
     `,
     credentialsSubmit: css`
       margin-left: ${spacing.md};

--- a/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.test.tsx
+++ b/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.test.tsx
@@ -3,11 +3,18 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import Credentials from './Credentials';
 
 describe('Credentials:: ', () => {
-  it('should render access and secret keys fields', () => {
+  it('should render access key, secret key, and role ARN fields in order', () => {
     render(<Credentials discover={jest.fn()} />);
 
-    expect(screen.getByTestId('aws_access_key-text-input')).toBeInTheDocument();
-    expect(screen.getByTestId('aws_secret_key-password-input')).toBeInTheDocument();
+    const accessKeyInput = screen.getByTestId('aws_access_key-text-input');
+    const secretKeyInput = screen.getByTestId('aws_secret_key-password-input');
+    const roleArnInput = screen.getByTestId('aws_role_arn-text-input');
+
+    expect(accessKeyInput).toBeInTheDocument();
+    expect(secretKeyInput).toBeInTheDocument();
+    expect(roleArnInput).toBeInTheDocument();
+    expect(accessKeyInput.compareDocumentPosition(secretKeyInput)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(secretKeyInput.compareDocumentPosition(roleArnInput)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it('should call discover on submit', () => {
@@ -15,8 +22,13 @@ describe('Credentials:: ', () => {
     render(<Credentials discover={discover} />);
 
     const form = screen.getByTestId('credentials-form');
+    fireEvent.change(screen.getByTestId('aws_role_arn-text-input'), {
+      target: { value: 'arn:aws:iam::123456789012:role/PmmRdsReadOnlyRole' },
+    });
     fireEvent.submit(form);
 
-    expect(discover).toHaveBeenCalled();
+    expect(discover).toHaveBeenCalledWith(
+      expect.objectContaining({ aws_role_arn: 'arn:aws:iam::123456789012:role/PmmRdsReadOnlyRole' })
+    );
   });
 });

--- a/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.tsx
+++ b/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.tsx
@@ -15,7 +15,7 @@ const Credentials: FC<CredentialsProps> = ({ discover }) => {
 
   const onSubmit = useCallback(
     (values: RDSCredentialsForm) => {
-      discover(values);
+      discover({ aws_access_key: '', aws_secret_key: '', aws_role_arn: '', ...values });
     },
     [discover]
   );
@@ -31,17 +31,26 @@ const Credentials: FC<CredentialsProps> = ({ discover }) => {
           data-testid="credentials-form"
         >
           <div className={styles.fieldsWrapper}>
+            <div className={styles.credentialsRow}>
+              <TextInputField
+                name={Messages.form.fields.awsAccessKey.name}
+                placeholder={Messages.form.fields.awsAccessKey.placeholder}
+                label={Messages.form.fields.awsAccessKey.label}
+                fieldClassName={styles.credentialsField}
+              />
+              <PasswordInputField
+                name={Messages.form.fields.awsSecretKey.name}
+                placeholder={Messages.form.fields.awsSecretKey.placeholder}
+                label={Messages.form.fields.awsSecretKey.label}
+                fieldClassName={styles.credentialsField}
+              />
+            </div>
             <TextInputField
-              name={Messages.form.fields.awsAccessKey.name}
-              placeholder={Messages.form.fields.awsAccessKey.placeholder}
-              label={Messages.form.fields.awsAccessKey.label}
-              fieldClassName={styles.credentialsField}
-            />
-            <PasswordInputField
-              name={Messages.form.fields.awsSecretKey.name}
-              placeholder={Messages.form.fields.awsSecretKey.placeholder}
-              label={Messages.form.fields.awsSecretKey.label}
-              fieldClassName={styles.credentialsField}
+              name={Messages.form.fields.awsRoleArn.name}
+              placeholder={Messages.form.fields.awsRoleArn.placeholder}
+              label={Messages.form.fields.awsRoleArn.label}
+              tooltipText={Messages.form.fields.awsRoleArn.tooltipText}
+              fieldClassName={styles.roleArnField}
             />
           </div>
         </form>

--- a/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.types.ts
+++ b/public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.types.ts
@@ -1,6 +1,7 @@
 export interface RDSCredentialsForm {
   aws_access_key: string;
   aws_secret_key: string;
+  aws_role_arn: string;
 }
 
 export interface CredentialsProps {

--- a/public/app/percona/add-instance/panel.types.ts
+++ b/public/app/percona/add-instance/panel.types.ts
@@ -13,6 +13,7 @@ export interface RemoteInstanceCredentials {
   region?: string;
   aws_access_key?: string;
   aws_secret_key?: string;
+  aws_role_arn?: string;
   azure_client_id?: string;
   azure_client_secret?: string;
   azure_tenant_id?: string;


### PR DESCRIPTION
PMM-13045

Link to the Feature Build: https://github.com/Percona-Lab/pmm-submodules/pull/4357 (SUBMODULES-4357)

## Summary
- Add optional AWS IAM role ARN input to the PMM Amazon RDS discovery form.
- Send `aws_role_arn` in `/services:discoverRDS` requests.
- Preserve the role ARN through RDS instance selection so Add RDS service payloads include it.
- Place the role ARN field below access key and secret key in the form.

## Related work
- JIRA: https://perconadev.atlassian.net/browse/PMM-13045
- Backend PR: https://github.com/percona/pmm/pull/5371
- Feature Build PR: https://github.com/Percona-Lab/pmm-submodules/pull/4357

## Testing
- `yarn jest --config jest.percona.config.js --runInBand --watch=false public/app/percona/add-instance/components/Discovery/components/Credentials/Credentials.test.tsx public/app/percona/add-instance/components/AddRemoteInstance/AddRemoteInstance.tools.test.ts`
- `yarn prettier --check <changed files>`
- `yarn eslint <changed files> --no-error-on-unmatched-pattern`
- `yarn build:nominify`
- Verified locally in PMM UI: access key and secret key on the first row, AWS IAM role ARN on the second row.

## Screenshot
<img width="2557" height="1059" alt="screenshot" src="https://github.com/user-attachments/assets/b4da8266-e987-4f13-8494-5a51592ce83b" />