### PR TITLE
PMM-15079: fix missing properties migration from timeseries panels

### DIFF
--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -230,6 +230,48 @@ describe('Graph Migrations', () => {
       expect(panel.options.legend.width).toBe(200);
     });
 
+    test('with sortBy and sortDesc', () => {
+      const old = {
+        angular: {
+          legend: {
+            alignAsTable: true,
+            show: true,
+            values: true,
+            avg: true,
+            max: true,
+            min: true,
+            sortBy: 'Mean',
+            sortDesc: true,
+          },
+        },
+      };
+      const panel = {} as PanelModel;
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
+      expect(panel.options.legend.sortBy).toBe('Mean');
+      expect(panel.options.legend.sortDesc).toBe(true);
+    });
+
+    test('with sort field (avg)', () => {
+      const old = {
+        angular: {
+          legend: {
+            alignAsTable: true,
+            show: true,
+            values: true,
+            avg: true,
+            max: true,
+            min: true,
+            sort: 'avg',
+            sortDesc: true,
+          },
+        },
+      };
+      const panel = {} as PanelModel;
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
+      expect(panel.options.legend.sortBy).toBe('Mean');
+      expect(panel.options.legend.sortDesc).toBe(true);
+    });
+
     test('hide allZeros', () => {
       const old = {
         angular: {

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -402,6 +402,18 @@ export function graphToTimeseriesOptions(angular: any): {
     if (legendConfig.hideEmpty) {
       overrides.push(getLegendHideFromOverride(ReducerID.allIsNull));
     }
+
+    const sortKey = legendConfig.sortBy ?? legendConfig.sort;
+    if (sortKey != null && sortKey !== '') {
+      const mapped = mapLegendSortKey(String(sortKey));
+      if (mapped) {
+        options.legend.sortBy = mapped;
+      }
+    }
+
+    if (legendConfig.sortDesc != null) {
+      options.legend.sortDesc = legendConfig.sortDesc;
+    }
   }
 
   // timeRegions migration
@@ -705,6 +717,25 @@ function getReducersFromLegend(obj: Record<string, unknown>): string[] {
     }
   }
   return ids;
+}
+
+/** Maps legacy graph legend sort keys to table column titles (fieldReducer.name). */
+function mapLegendSortKey(sortKey: string): string | undefined {
+  const reducer = fieldReducers.getIfExists(sortKey);
+  if (reducer) {
+    return reducer.name;
+  }
+
+  const legacy: Record<string, string> = {
+    avg: 'Mean',
+    mean: 'Mean',
+    max: 'Max',
+    min: 'Min',
+    total: 'Total',
+    current: 'Last',
+  };
+
+  return legacy[sortKey.toLowerCase()] ?? sortKey;
 }
 
 function migrateHideFrom(panel: {

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -720,7 +720,7 @@ function getReducersFromLegend(obj: Record<string, unknown>): string[] {
 }
 
 /** Maps legacy graph legend sort keys to table column titles (fieldReducer.name). */
-function mapLegendSortKey(sortKey: string): string | undefined {
+function mapLegendSortKey(sortKey: string): string {
   const reducer = fieldReducers.getIfExists(sortKey);
   if (reducer) {
     return reducer.name;


### PR DESCRIPTION
PMM-15079

SUBMODULES-4367

Fix panel migration to re-instate default sorting on timeseries panels.

Opened PR upstream as well:
https://github.com/grafana/grafana/pull/125137